### PR TITLE
Add Fast Triad sandbox analysis notebook

### DIFF
--- a/notebooks/fast_triad_sandbox.ipynb
+++ b/notebooks/fast_triad_sandbox.ipynb
@@ -1,0 +1,223 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "581203d9",
+   "metadata": {},
+   "source": [
+    "SPDX-License-Identifier: GPL-3.0-or-later — (c) 2025 Ulrich Warring and contributors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2274a8ec",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates the **Fast Triad** A–D–M screening on simulated sandbox data. It loads three CSV tables, computes screening flags, and produces diagnostic plots and reports. See [docs/DATASETS.md](../docs/DATASETS.md) for dataset details. The expected CSV schema is: `heating.csv` with `trap_id, run_id, mode, frequency_hz, heating_rate_quanta_per_s, heating_rate_err`; `sb_trials.csv` with `trap_id, run_id, sequence, outcome, t_rel_s`; and `events.csv` with `trap_id, run_id, t_s`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5032b380",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import scipy\n",
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "print('Python:', sys.version)\n",
+    "print('numpy:', np.__version__)\n",
+    "print('pandas:', pd.__version__)\n",
+    "print('scipy:', scipy.__version__)\n",
+    "print('matplotlib:', matplotlib.__version__)\n",
+    "\n",
+    "%matplotlib inline\n",
+    "np.random.seed(2025)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73e1099d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parameters (edit as needed)\n",
+    "from pathlib import Path\n",
+    "\n",
+    "DATA_ROOT = 'data-sandbox/clean'  # or 'data' after unzipping other archives\n",
+    "OUT_DIR = 'out'\n",
+    "PLOT_DIR = 'out/plots'\n",
+    "\n",
+    "Path(OUT_DIR).mkdir(parents=True, exist_ok=True)\n",
+    "Path(PLOT_DIR).mkdir(parents=True, exist_ok=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f5480e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import FastTriadAnalyzer\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.append(str(Path('src').resolve()))\n",
+    "from flyby.triad import FastTriadAnalyzer\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdd10a87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load sandbox data\n",
+    "analyzer = FastTriadAnalyzer()\n",
+    "analyzer.load_data(DATA_ROOT)\n",
+    "\n",
+    "dfs = {'heating': analyzer.heating, 'sb_trials': analyzer.trials, 'events': analyzer.events}\n",
+    "for name, df in dfs.items():\n",
+    "    print(f'{name}:')\n",
+    "    if df is not None and not df.empty:\n",
+    "        display(df.head())\n",
+    "    else:\n",
+    "        print('  no data')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ded75543",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate A–D–M statistics\n",
+    "results = analyzer.evaluate_data()\n",
+    "results = results[['trap_id','run_id','A_stat','A_p','b_A','D_stat','D_p','b_D','M_stat','M_p','b_M']]\n",
+    "results\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e57f41d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate CSV/JSON summaries and default plots\n",
+    "analyzer.generate_output(OUT_DIR)\n",
+    "\n",
+    "from pathlib import Path\n",
+    "summary_path = Path(OUT_DIR) / 'triad_summary.csv'\n",
+    "report_path = Path(OUT_DIR) / 'triad_report.json'\n",
+    "png_paths = sorted(Path(PLOT_DIR).glob('*.png'))\n",
+    "print('Created:', summary_path, report_path)\n",
+    "print('Plots:')\n",
+    "for p in png_paths:\n",
+    "    print(' -', p)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9a7b20f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inline diagnostics per run\n",
+    "from pathlib import Path\n",
+    "if analyzer.results is not None and not analyzer.results.empty:\n",
+    "    for _, row in analyzer.results.iterrows():\n",
+    "        trap_id, run_id = row['trap_id'], row['run_id']\n",
+    "        fig, axes = plt.subplots(3, 1, figsize=(8, 10))\n",
+    "        fig.suptitle(f'{trap_id} / {run_id} — Fast Triad diagnostics')\n",
+    "        # Heating vs frequency\n",
+    "        dfH = analyzer.heating.query('trap_id==@trap_id and run_id==@run_id')\n",
+    "        if dfH is not None and not dfH.empty:\n",
+    "            dH = dfH.dropna(subset=['frequency_hz', 'heating_rate_quanta_per_s'])\n",
+    "            axes[0].loglog(dH['frequency_hz'], dH['heating_rate_quanta_per_s'], 'o')\n",
+    "        axes[0].set_xlabel('Mode frequency (Hz)')\n",
+    "        axes[0].set_ylabel('Heating rate (quanta/s)')\n",
+    "        axes[0].grid(True, which='both', ls=':')\n",
+    "        # Binary outcomes\n",
+    "        dfT = analyzer.trials.query('trap_id==@trap_id and run_id==@run_id')\n",
+    "        if dfT is not None and not dfT.empty and 't_rel_s' in dfT:\n",
+    "            dT = dfT.sort_values('t_rel_s')\n",
+    "            axes[1].step(dT['t_rel_s'], dT['outcome'], where='post')\n",
+    "        axes[1].set_xlabel('t_rel (s)')\n",
+    "        axes[1].set_ylabel('Outcome (0/1)')\n",
+    "        axes[1].grid(True, ls=':')\n",
+    "        # Event counts\n",
+    "        dfE = analyzer.events.query('trap_id==@trap_id and run_id==@run_id')\n",
+    "        if dfE is not None and not dfE.empty and 't_s' in dfE:\n",
+    "            dE = dfE.sort_values('t_s')\n",
+    "            if len(dE) > 1:\n",
+    "                bin_s = max((dE['t_s'].max() - dE['t_s'].min()) / 30.0, 1.0)\n",
+    "                bins = np.arange(dE['t_s'].min(), dE['t_s'].max() + bin_s, bin_s)\n",
+    "                counts, edges = np.histogram(dE['t_s'], bins=bins)\n",
+    "                centers = 0.5 * (edges[:-1] + edges[1:])\n",
+    "                axes[2].plot(centers, counts, '-o')\n",
+    "        axes[2].set_xlabel('t (s)')\n",
+    "        axes[2].set_ylabel('Event count per bin')\n",
+    "        axes[2].grid(True, ls=':')\n",
+    "        fig.tight_layout(rect=[0, 0.03, 1, 0.95])\n",
+    "        fig.savefig(Path(PLOT_DIR) / f'{trap_id}__{run_id}.png', dpi=150)\n",
+    "        display(fig)\n",
+    "        plt.close(fig)\n",
+    "else:\n",
+    "    print('No runs to plot.')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a754d2bc",
+   "metadata": {},
+   "source": [
+    "The A/D/M flags (b_A, b_D, b_M) highlight runs where the corresponding analog, digital, or memory test yielded p-values below 5e-3. These results are a screening step only; flagged runs merit deeper investigation but do not constitute a discovery claim. The datasets used here are fully simulated, yet the same schema applies to real measurements."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c3ddfaf",
+   "metadata": {},
+   "source": [
+    "### Optional: run with alternative dataset\n",
+    "\n",
+    "Unzip a larger sandbox dataset and update `DATA_ROOT` before rerunning the analysis cells above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4262e2ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !unzip datasets/sandbox_flyby_dataset.zip -d data/\n",
+    "# DATA_ROOT = 'data/flyby'\n",
+    "# analyzer.load_data(DATA_ROOT)\n",
+    "# (re-run evaluation and plotting cells)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a28ad155",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "Analysis environment specified in `environment.yml`. This notebook is licensed under GPL-3.0-or-later; please keep analysis steps transparent and reproducible in any contributions."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `fast_triad_sandbox.ipynb` with GPL header and sandbox-focused context
- load simulated CSVs, run Fast Triad A–D–M evaluation, and emit plots and reports
- show per-run diagnostics and instructions for running alternative datasets

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbd45c23d483339b2d9cfd3dbfeb00