### PR TITLE
docs: add project wiki and sync workflow

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,51 @@
+name: Sync docs/wiki to GitHub Wiki
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/wiki/**'
+      - '.github/workflows/wiki-sync.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: true
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare wiki workspace
+        run: |
+          set -euo pipefail
+          REPO="${GITHUB_REPOSITORY}"
+          WIKI_URL="https://x-access-token:${{ secrets.WIKI_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${REPO}.wiki.git"
+          echo "Cloning wiki: ${WIKI_URL}"
+          rm -rf /tmp/wiki
+          git clone --depth=1 "${WIKI_URL}" /tmp/wiki
+          # Ensure docs/wiki exists
+          if [ ! -d docs/wiki ]; then
+            echo "docs/wiki not found; nothing to sync."
+            exit 0
+          fi
+          # Rsync (delete removed files on wiki)
+          rsync -av --delete --exclude='.git' docs/wiki/ /tmp/wiki/
+          cd /tmp/wiki
+          # Commit only if there are changes
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "docs(wiki): sync from main repo docs/wiki on ${GITHUB_SHA}"
+            git push origin HEAD:master
+          else
+            echo "No changes to sync."
+          fi

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -1,0 +1,13 @@
+SPDX-License-Identifier: GPL-3.0-or-later
+
+# Contributing
+
+We welcome contributions (code, simulated datasets, documentation). All contributions are GPLv3.
+
+## Guidelines
+- Follow the CSV schema and clearly label simulated vs experimental data.
+- Include minimal metadata (trap, species, geometry, pressure/temperature if relevant).
+- Open a PR with a clear description; CI should pass.
+
+## Community values
+Honesty, openness, and reproducibility. This is publicly funded research; we share methods and results from day one. We use AI tools (e.g., ChatGPT/Codex) in a hybrid, human-supervised workflow to ensure scientific integrity.

--- a/docs/wiki/Data-and-Workflow.md
+++ b/docs/wiki/Data-and-Workflow.md
@@ -1,0 +1,23 @@
+SPDX-License-Identifier: GPL-3.0-or-later
+
+# Data & Workflow
+
+## Current status: simulated datasets (sandbox)
+The repo ships **sandbox** datasets only (not experimental). See `DATASETS.md` for formats and quick start.
+
+**Schema (CSV):**
+- `heating.csv`: trap_id, run_id, mode, frequency_hz, heating_rate_quanta_per_s, heating_rate_err
+- `sb_trials.csv`: trap_id, run_id, sequence, outcome (0/1), t_rel_s
+- `events.csv`: trap_id, run_id, t_s
+
+## Running the Fast Triad
+```bash
+python scripts/run_triad.py --data-root data-sandbox/clean --out out
+```
+
+Outputs: `out/triad_summary.csv`, `out/triad_report.json`, and `out/plots/*.png`.
+
+Reproducibility
+- Environment via `environment.yml` (conda) or `requirements.txt` (pip)
+- CI to validate schema/analysis (optional)
+- Pre-registration of thresholds and windowing for consistency

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,14 @@
+SPDX-License-Identifier: GPL-3.0-or-later
+
+# flyby-fingerprints — Project Wiki
+
+**Purpose.** This open, GPLv3 research program develops robust methods to identify *fingerprints of fly-by (residual-gas) collisions* in trapped-ion heating-rate measurements. We start with **simulated sandbox datasets** to validate the *Fast Triad (A–D–M)* screening and will later test on PAULA (lab “one-world” data). Longer-term, we invite other ion-trapping groups to contribute datasets under shared schemas.
+
+**Approach (Fast Triad).**
+- **Analog (A):** mode-resolved heating vs. frequency to test for impulsive admixtures beyond power-law backgrounds.
+- **Digital (D):** burstiness and runs in interleaved binary trials (e.g., RSB/BSB).
+- **Memory (M):** short-lag correlations in event-time streams (e.g., Ljung–Box, Allan variance).
+
+**Principles.** Honesty, openness, reproducibility. All code and analyses are public from day one; derivatives remain open (GPLv3). We use modern tooling (e.g., ChatGPT/Codex) within a human-supervised, transparent workflow.
+
+See: [Physics](Physics.md) · [Data and Workflow](Data-and-Workflow.md) · [Contributing](Contributing.md) · [References](References.md)

--- a/docs/wiki/Physics.md
+++ b/docs/wiki/Physics.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: GPL-3.0-or-later
+
+# Underlying Physics (brief)
+
+## Trapped-ion heating: backgrounds vs. fly-by collisions
+Motional heating in RF Paul traps can arise from:
+- **Electric-field noise / patch potentials** — typically modeled as power-law spectral densities, often decreasing with frequency and electrode-ion distance.
+- **Fly-by (residual-gas) collisions** — impulsive momentum kicks from dilute background gas, weakly frequency-dependent when averaged over modes, and potentially clustered in time if pressure fluctuates.
+
+### Expected fingerprints
+- **A (Analog):** Deviation from a pure power-law Γ̇(ω) via a small additive (weakly ω-dependent) term consistent with rare impulses.
+- **D (Digital):** Overdispersion and abnormal run structure in binary outcomes (e.g., RSB/BSB), reflecting bursty intervals.
+- **M (Memory):** Short-lag autocorrelation above white-noise baselines in event counts (e.g., Ljung–Box significance; characteristic Allan-variance slope).
+
+### Confounders & controls
+- Micromotion (RF), laser scatter, servo or digitizer artifacts, pressure/temperature drift, analysis pipeline bias. Mitigate via pre-registration, blinding of toggles, hardware heterogeneity, and end-to-end synthetic injections.
+
+For deeper background, see [References](References.md).

--- a/docs/wiki/References.md
+++ b/docs/wiki/References.md
@@ -1,0 +1,19 @@
+SPDX-License-Identifier: GPL-3.0-or-later
+
+# References (selected primary sources)
+
+**Ion-trap noise & heating (surveys)**
+- Brownnutt, M., et al. “Ion-trap measurements of electric-field noise near surfaces.” *Rev. Mod. Phys.* **87**, 1419 (2015). DOI: 10.1103/RevModPhys.87.1419
+
+**Trapped-ion fundamentals**
+- Leibfried, D., Blatt, R., Monroe, C., Wineland, D. “Quantum dynamics of single trapped ions.” *Rev. Mod. Phys.* **75**, 281 (2003). DOI: 10.1103/RevModPhys.75.281
+- James, D. F. V. “Quantum dynamics of cold trapped ions.” *Appl. Phys. B* **66**, 181–190 (1998). DOI: 10.1007/s003400050373
+- Major, F. G., Gheorghe, V. N., Werth, G. *Charged Particle Traps: Physics and Techniques of Charged Particle Field Confinement.* Springer (2005). DOI: 10.1007/b138787
+
+**Background-gas collisions / impulsive heating**
+- DeVoe, R. G. “Power-Law Distributions for a Trapped Ion Interacting with a Classical Buffer Gas.” *Phys. Rev. Lett.* **102**, 063001 (2009). DOI: 10.1103/PhysRevLett.102.063001
+
+**Surface noise mitigation examples**
+- Hite, D. A., et al. “100-fold reduction of electric-field noise in an ion trap cleaned with in-situ Argon-ion beam.” *Phys. Rev. Lett.* **109**, 103001 (2012). DOI: 10.1103/PhysRevLett.109.103001
+
+*(Note: This list is intentionally compact; expand with lab-specific literature as the wiki grows.)*

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,7 @@
+SPDX-License-Identifier: GPL-3.0-or-later
+
+* [[Home]]
+* [[Physics]]
+* [[Data and Workflow]]
+* [[Contributing]]
+* [[References]]


### PR DESCRIPTION
## Summary
- add project wiki explaining purpose and Fast Triad approach
- document underlying physics and key literature with DOIs
- outline data schema, simulated datasets, workflow, and contribution guidelines
- add GitHub Actions workflow to sync docs/wiki to GitHub Wiki
- update wiki sidebar with wiki-style links

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbd75dd5e8833393d4c8c75e813236