### PR TITLE
Tests: Interaction Diagnostics, Baseline Validator, Constraints Schema (Phase-2)

### DIFF
--- a/tests/test_baseline_validator.py
+++ b/tests/test_baseline_validator.py
@@ -1,0 +1,38 @@
+import os, json
+from simulations.integration.baseline_validator import validate_baseline
+
+
+def test_uncertainty_aware_pass(tmp_path, monkeypatch):
+    """
+    With value=1.1 and sigma=0.08 (=> 2σ/val ~ 0.145),
+    a 1.0 baseline (dev ~ 0.091) should pass via uncertainty rule.
+    """
+    monkeypatch.chdir(tmp_path)
+    baseline = {"x": 1.0}
+    refs = {"x": {"value": 1.1, "sigma": 0.08}}
+    report = validate_baseline(baseline, refs, rel_tolerance=0.20, sigma_N=2.0)
+    assert report["x"]["pass"] is True
+    assert os.path.exists("artifacts/baseline/benchmark_comparisons.json")
+
+
+def test_fixed_tolerance_fail_then_pass(tmp_path, monkeypatch):
+    """
+    For a ref without sigma, rely on rel_tolerance.
+    Dev = 0.25 with tol=0.20 -> fail; with tol=0.30 -> pass.
+    """
+    monkeypatch.chdir(tmp_path)
+    baseline = {"y": 1.25}
+    refs = {"y": 1.0}
+    report = validate_baseline(baseline, refs, rel_tolerance=0.20)
+    assert report["y"]["pass"] is False
+    report = validate_baseline(baseline, refs, rel_tolerance=0.30)
+    assert report["y"]["pass"] is True
+
+
+def test_missing_sim_value_is_reported(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    baseline = {}
+    refs = {"z": {"value": 1.0, "sigma": 0.0}}
+    report = validate_baseline(baseline, refs)
+    assert report["z"]["pass"] is False
+    assert report["z"]["reason"] == "missing_sim_value"

--- a/tests/test_constraint_mapper_schema.py
+++ b/tests/test_constraint_mapper_schema.py
@@ -1,0 +1,54 @@
+import json, os, textwrap
+from pathlib import Path
+from simulations.integration.constraint_mapper import apply_physical_constraints
+
+PC_PATH = Path("data/metadata/physical_constraints.json")
+
+
+def test_schema_file_exists_and_is_json():
+    assert PC_PATH.exists(), "constraints file missing"
+    with open(PC_PATH, "r", encoding="utf-8") as f:
+        spec = json.load(f)
+    assert "relations" in spec and isinstance(spec["relations"], list)
+
+
+def test_no_c_like_and_in_when_clauses():
+    """Guard against accidental '&&' which Python eval cannot parse."""
+    txt = PC_PATH.read_text(encoding="utf-8")
+    assert "&&" not in txt, "replace '&&' with 'and' in 'when' expressions"
+
+
+def test_mapper_handles_missing_schema_gracefully(tmp_path, monkeypatch):
+    """If file absent, mapper must no-op and return input unchanged."""
+    monkeypatch.chdir(tmp_path)
+    # ensure file is absent in cwd
+    os.makedirs("data/metadata", exist_ok=True)
+    # do not create physical_constraints.json here
+    params = {"pressure": 1.0, "temperature": 300.0}
+    out = apply_physical_constraints(params)
+    assert out == params
+
+
+def test_mapper_applies_example_relation(tmp_path, monkeypatch):
+    """Simple P-T scaling rule should update 'pressure' when condition is true."""
+    monkeypatch.chdir(tmp_path)
+    os.makedirs("data/metadata", exist_ok=True)
+    Path("data/metadata/physical_constraints.json").write_text(
+        textwrap.dedent("""\
+        {
+          "relations": [
+            {
+              "out": "pressure",
+              "expr": "pressure * (temperature/300.0)",
+              "when": "'pressure' in locals() and 'temperature' in locals()"
+            }
+          ]
+        }
+        """),
+        encoding="utf-8",
+    )
+    params = {"pressure": 1.0, "temperature": 600.0}
+    out = apply_physical_constraints(params)
+    assert out["pressure"] == 2.0
+    # other keys preserved
+    assert out["temperature"] == 600.0

--- a/tests/test_guardian_phase2_toggle.py
+++ b/tests/test_guardian_phase2_toggle.py
@@ -1,0 +1,14 @@
+import os
+from pathlib import Path
+from simulations.validation.guardian_gates import _phase2_enabled  # type: ignore
+
+
+def test_phase2_toggle(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs("docs/wiki/Phase_Gates", exist_ok=True)
+    # Initially off
+    assert _phase2_enabled() is False
+    # Create gate file -> on
+    Path("docs/wiki/Phase_Gates/Phase_2_Integration.md").write_text("# Phase 2", encoding="utf-8")
+    # Need to re-import to pick new cwd? The function resolves absolute path each call, so OK.
+    assert _phase2_enabled() is True

--- a/tests/test_interaction_diagnostics.py
+++ b/tests/test_interaction_diagnostics.py
@@ -1,0 +1,24 @@
+import os, json
+from simulations.integration.interaction_diagnostics import diagnose_interactions
+
+
+def test_zero_sum_safe(tmp_path, monkeypatch):
+    """No div-by-zero when all individual totals are zero."""
+    monkeypatch.chdir(tmp_path)
+    individual = {"rf": {"k": 0.0}, "patch": {"k": 0.0}}
+    combined = {"k": 0.0}
+    flagged = diagnose_interactions(individual, combined, rel_threshold=0.10, noise_floor=1e-9)
+    assert flagged == {}  # should not flag; denominator clamped by noise_floor
+    assert (tmp_path / "artifacts/baseline/interaction_matrix.json").exists()
+
+
+def test_flags_above_threshold_and_writes_json(tmp_path, monkeypatch):
+    """If combined deviates >10% from sum, it must be flagged and JSON written."""
+    monkeypatch.chdir(tmp_path)
+    individual = {"rf": {"rate": 1.0}, "patch": {"rate": 0.0}}
+    combined = {"rate": 1.2}  # 20% deviation
+    flagged = diagnose_interactions(individual, combined, rel_threshold=0.10, noise_floor=1e-12)
+    assert "rate" in flagged and flagged["rate"] > 0.10
+    out = json.loads(open("artifacts/baseline/interaction_matrix.json").read())
+    assert isinstance(out, dict) and "rate" in out
+    assert out["rate"] == flagged["rate"]  # stored strengths match returned values


### PR DESCRIPTION
## Summary
- add focused pytest coverage for interaction diagnostics, baseline validator, constraint mapper, and guardian phase-2 toggles
- harden constraint mapper evaluation sandbox so schema rules using `locals()` execute as intended

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9aac8fe5c83338cb54aed5508549e