### PR TITLE
feat: simulation-first museum entrance rollout

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,10 @@
+---
+name: Bug report
+about: Report a bug in simulation/validation
+labels: bug
+---
+
+**Component**: simulation | validation | docs  
+**Expected vs. observed**:  
+**Repro steps**:  
+**Logs/plots**:

--- a/.github/ISSUE_TEMPLATE/docs_task.md
+++ b/.github/ISSUE_TEMPLATE/docs_task.md
@@ -1,0 +1,9 @@
+---
+name: Docs task
+about: Improve catalogs, tutorials, references
+labels: documentation, good first issue
+---
+
+**Page(s)**:  
+**Proposed change**:  
+**Why helpful**:

--- a/.github/ISSUE_TEMPLATE/simulation_feature.md
+++ b/.github/ISSUE_TEMPLATE/simulation_feature.md
@@ -1,0 +1,10 @@
+---
+name: Simulation feature
+about: Propose a new/extended physical effect or improvement
+labels: enhancement, help wanted
+---
+
+**Effect/Model**:  
+**Parameters & ranges**:  
+**Validation idea/tests**:  
+**References**:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,13 @@
 ## Summary
--
+Describe the change and which component it touches (simulation / validation / docs).
 
-## Testing
-- [ ] `python tools/format_gate.py`
-- [ ] `pytest`
+## Guardian Impact
+- Physics deviation tests: (n/a | improved | risk)
+- Background coverage: (n/a | improved | risk)
+- Ground-truth integrity: (n/a | improved | risk)
+- ROC/Null harness: (n/a | improved | risk)
 
-## Guardian Checklist
-- [ ] Uncertainty propagation interface
-- [ ] Failure mode documentation section
-- [ ] `requires_cross_validation` flags for H-risk interactions
-
-## Council Sign-off — Phase: Foundation
-- Guardian: ✅ Protective criteria met / ⬜ comments below
-- Architect: ✅ Structural validation passed / ⬜ comments below
-- Integrator: ✅ Milestone completion verified / ⬜ comments below
+## Checklist
+- [ ] Tests added/updated
+- [ ] `scripts/guardian-cli.py` passes locally or explains expected fail
+- [ ] Docs updated

--- a/.github/workflows/guardian-validation.yml
+++ b/.github/workflows/guardian-validation.yml
@@ -1,0 +1,22 @@
+name: Guardian Validation
+on:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+jobs:
+  guardian:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps (if any)
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run Guardian CLI
+        run: |
+          python scripts/guardian-cli.py --summary-json > guardian_summary.json || true
+          cat guardian_summary.json
+          python scripts/guardian-cli.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,72 +1,19 @@
+# Contributing
 
-# Contributing to flyby-fingerprints-sandbox
+## Branching
+- `main` = **certified** state only (protected).
+- Work on feature branches: `feat/*`, `fix/*`, `docs/*`.
+- PRs into `main` must pass **Guardian Validation** CI.
 
-Thank you for considering contributing to this project!
-This repository is a sandbox environment for analyzing heating-rate datasets of trapped ions to identify fingerprints of fly-by (residual-gas) collisions.
+## Paths
+- Simulation fidelity → `simulation_backend/*`
+- Validation/Gate → `simulations/validation/*`, `scripts/guardian-cli.py`
+- Docs → `docs/*`
 
----
+## PR Checklist
+- [ ] Tests added/updated
+- [ ] `scripts/guardian-cli.py` runs locally with non-error exit
+- [ ] Affected Guardian checks explained in PR template
+- [ ] Relevant docs updated
 
-## Maintainer
-Ulrich Warring
-University of Freiburg
-
----
-
-## How to Contribute
-
-### 1. Set up the environment
-You can use either **conda** or **pip**:
-
-**Conda (recommended):**
-```bash
-conda env create -f environment.yml
-conda activate flyby-fingerprints
-```
-
-**Pip:**
-```bash
-python -m venv venv
-source venv/bin/activate   # Linux/Mac
-venv\Scripts\activate    # Windows
-pip install -r requirements.txt
-```
-
-### 2. Fork and clone the repository
-- Fork the repository on GitHub.
-- Clone your fork locally:
-```bash
-git clone https://github.com/<your-username>/flyby-fingerprints-sandbox.git
-```
-
-### 3. Create a new branch
-```bash
-git checkout -b feature/your-feature-name
-```
-
-### 4. Make your changes
-- Add or modify analysis scripts, data schemas, or documentation.
-- Ensure that existing functionality still works.
-- Run `python tools/format_gate.py` to check formatting and linting.
-- Run `pytest` to execute the test suite.
-
-### 5. Commit and push
-```bash
-git add .
-git commit -m "Describe your changes clearly"
-git push origin feature/your-feature-name
-```
-
-### 6. Open a Pull Request
-- On GitHub, open a pull request from your branch into `main`.
-- Describe the purpose of your contribution and any relevant details.
-
----
-
-## Code of Conduct
-- Be respectful, collaborative, and transparent.
-- All contributions must be released under the GPLv3 license.
-- Provide clear documentation for any new analysis or data formats.
-
----
-
-Thank you for helping to make this sandbox a robust community resource!
+See `.github/pull_request_template.md`.

--- a/README.md
+++ b/README.md
@@ -1,50 +1,80 @@
-# Flyby Fingerprints Sandbox
+# 🛡️ Flyby Fingerprints: Simulation-First Collision Detection Framework
 
-[![CI - Fast (unit)](https://github.com/uwarring82/-flyby-fingerprints-sandbox/actions/workflows/ci-fast.yml/badge.svg)](https://github.com/uwarring82/-flyby-fingerprints-sandbox/actions/workflows/ci-fast.yml)
-[![CI - Integration (toy)](https://github.com/uwarring82/-flyby-fingerprints-sandbox/actions/workflows/ci-integration.yml/badge.svg)](https://github.com/uwarring82/-flyby-fingerprints-sandbox/actions/workflows/ci-integration.yml)
+> **Critical Notice**  
+> This project is **simulation-first**. Analysis of real data is **gated** by Guardian certification of the simulation + validation stack. PRs into `main` require the **Guardian Validation** CI check to pass.
 
----
+![Guardian Validation](https://github.com/uwarring82/-flyby-fingerprints-sandbox/actions/workflows/guardian-validation.yml/badge.svg)
 
-## Project Aim
+## 🎯 Mission
+Detect weak residual-gas collisions in trapped-ion systems via rigorously validated fingerprint analysis—starting with a comprehensive simulation of all known background/systematic effects.
 
-This sandbox explores how trapped ions respond to **flyby collisions with residual-gas particles**.  
-Our central challenge is to **disentangle true collision fingerprints from background heating mechanisms**.
+## 🏗️ Three-Phase Architecture
 
-**Phase-1 priority:**  
-We are first of all building a **dedicated simulation backbone** that carefully accounts for relevant background sources (technical noise, trap imperfections, patch potentials). Only once these are quantitatively under control will we search for unique flyby signatures.
+- **Phase 1: Simulation Backend (ACTIVE) ✅**  
+  Trapped-ion dynamics (target <0.1% deviation), Tier-1..3 background models, preliminary collision-injection API, Guardian validation framework (ROC, null testing).
+- **Phase 2: Algorithm Development (GATED) 🔗**  
+  Requires certified Phase-1. A-D-M triad pipeline and Heptad analysis.
+- **Phase 3: Real Data Analysis (GATED) 🔗**  
+  Requires certified Phase-2. Historical re-analysis, new campaigns, community portal.
 
----
+> **GATED = dependent on prior certified phase.** Work may proceed on feature branches but **cannot merge to `main`** until certification passes.
 
-## Conceptual Motivation
+## 🚀 Quick Start
 
-Flyby events and their heating signatures carry a remarkable degree of **self-similarity**:
-
-* **Scaling of Interaction Potentials** — The Coulomb force ∝ 1/r makes deflections look similar across scales; small-impact strong events and large-impact weak events form a continuum.
-* **Self-similar distributions** — Many flybys accumulate into power-law tails (Lévy-like), so zooming in reveals the same shape.
-* **Scale-invariant heating dynamics** — Normalized groups (impact parameter / Debye length, collision time / trap period) repeat physics independent of absolute trap scale.
-* **Experimental observables** — Heating rates vs. pressure often follow power laws, signaling scale-invariant processes.
-
-**Critical nuance:** Real traps break strict self-similarity (finite size, RF drive, screening). What survives experimentally are **approximate scaling laws** whose deviations encode valuable, trap-specific physics.
-
----
-
-## Quickstart
-
+### Physicists
 ```bash
+git clone https://github.com/uwarring82/-flyby-fingerprints-sandbox
+cd flyby-fingerprints-sandbox
 python -m venv .venv && source .venv/bin/activate
-pip install -e . -r requirements.txt
-
-# run toy dataset (fast check)
-python -m flyby.triad --data-root data/toy --out out
-
-Outputs:
-    •   out/triad_summary.csv
-    •   out/triad_report.json
+pip install -r requirements.txt
+python -m simulations.validation.guardian_gates  # if present
 ```
 
-⸻
+Algorithm Developers
 
-Next steps
-1.  Simulation backbone: rigorous modeling of background mechanisms.
-2.  Scaling analysis: check if normalized impact-parameter / energy-transfer distributions collapse onto universal curves.
-3.  Fingerprint search: identify deviations from scale-invariance as possible flyby collision signatures.
+```
+# NOTE: Collision injection API is preliminary and may change pending backend completion.
+from simulation_backend import api as sim
+data, gt = sim.generate_background_only_with_markers()
+# Implement your detector; compare to markers/gt.
+```
+
+Experimentalists
+•See /docs/systematic_effects.md for the effect catalog and contribution hooks.
+•Open an issue with your trap parameters to prioritize validation targets.
+
+📊 Status Dashboard
+
+| Component | Status | Guardian State | Progress | Next Milestone |
+| --- | --- | --- | --- | --- |
+| Physics Engine | 🟡 | In Review | ~60% | Coulomb interaction precision sweep |
+| Background Effects | 🟡 | Pending | ~40% | Tier-2 drift & RF pickup models |
+| Collision Injection | 🔴 | Pending | ~10% | Stable API v0 with ground-truth tags |
+| Validation FW | 🟡 | In Review | ~30% | ROC harness + null-hypothesis suite |
+
+Legend (Guardian): Pending → In Review → Passed or Action Required
+
+See STATUS.md for details.
+
+🛡️ Guardian Requirements (merge gates)
+•Physics deviation target: < 0.1% (tracked tests).
+•Tier-1..3 backgrounds modeled with tests & bounds.
+•Ground-truth preservation in I/O and APIs.
+•ROC AUC > 0.95 at 10:1 SNR (sim suites).
+•PRs → CI Guardian Validation must pass.
+
+🤝 Contributing
+
+Start with CONTRIBUTING.md. Choose your path:
+•Simulation (physics fidelity, performance)
+•Validation (tests, ROC/Null suites, Guardian)
+•Documentation (effect catalog, tutorials)
+
+📚 Learn More
+•/docs/architecture_overview.md
+•/docs/systematic_effects.md
+•/docs/guardian_framework.md
+•Project docs site (when enabled): see badge/link in STATUS.md
+
+Repository Principle:
+Every unvalidated systematic effect is a potential false discovery waiting to happen.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,13 @@
+# Project Status (manual until CI automation v2)
+
+Last updated: YYYY-MM-DD
+
+## Guardian State Summary
+- Physics Engine: In Review
+- Background Effects: Pending
+- Collision Injection: Pending
+- Validation Framework: In Review
+
+## Notes
+- Guardian CI badge: see README.
+- Next automation: publish metrics from `scripts/guardian-cli.py --summary-json`.

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,0 +1,7 @@
+# Architecture Overview
+
+- Phase 1 → Simulation backend (certification target)
+- Phase 2 → Algorithms (gated on Phase 1)
+- Phase 3 → Real data (gated on Phase 2)
+
+Guardian = automated CI + human review of scientific adequacy (thresholds in README).

--- a/docs/guardian_framework.md
+++ b/docs/guardian_framework.md
@@ -1,0 +1,18 @@
+# Guardian Framework
+
+## Purpose
+Automated, impartial gate that blocks merges if validation is insufficient.
+
+## Checks (examples)
+- Physics deviation tests
+- Background coverage tests
+- Ground-truth conservation tests
+- ROC / Null-hypothesis harness
+
+## Usage
+```bash
+python scripts/guardian-cli.py --all
+echo $?
+```
+
+Exit code 0 == pass; non-zero blocks PR via CI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Flyby Fingerprints Docs
+
+- Start: `architecture_overview.md`
+- Effects: `systematic_effects.md`
+- Guardian: `guardian_framework.md`

--- a/docs/systematic_effects.md
+++ b/docs/systematic_effects.md
@@ -1,0 +1,15 @@
+# Systematic Effects Catalog (living document)
+
+## Tier-1 (Dominant)
+- RF heating … (placeholder structure)
+- Micromotion …
+
+## Tier-2
+- Laser intensity noise …
+- Frequency drifts …
+
+## Tier-3
+- Background gas pressure fluctuations …
+
+### How to Contribute
+- Open `docs_task` issue with: effect, model, parameters, refs, tests.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: Flyby Fingerprints
+repo_url: https://github.com/uwarring82/-flyby-fingerprints-sandbox
+nav:
+  - Home: docs/index.md
+  - Architecture: docs/architecture_overview.md
+  - Systematic Effects: docs/systematic_effects.md
+  - Guardian: docs/guardian_framework.md
+theme:
+  name: material

--- a/scripts/guardian-cli.py
+++ b/scripts/guardian-cli.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Minimal Guardian CLI (v0): returns non-zero if any check fails.
+Extend with real tests as they land.
+"""
+import sys
+import json
+
+def check_physics_deviation():
+    # TODO: call real test suite / import assertions
+    return True, {"target": "<0.1%", "measured": None}
+
+
+def check_background_coverage():
+    # TODO
+    return False, {"tiers": {"T1": "partial", "T2": "pending", "T3": "pending"}}
+
+
+def check_ground_truth_integrity():
+    # TODO
+    return True, {}
+
+
+def check_roc_auc():
+    # TODO
+    return False, {"auc@10to1": None, "target": ">=0.95"}
+
+
+def main():
+    checks = [
+        ("physics_deviation", check_physics_deviation),
+        ("background_coverage", check_background_coverage),
+        ("ground_truth_integrity", check_ground_truth_integrity),
+        ("roc_auc", check_roc_auc),
+    ]
+    summary = {}
+    ok_all = True
+    for name, fn in checks:
+        ok, meta = fn()
+        summary[name] = {"ok": ok, "meta": meta}
+        ok_all &= ok
+
+    if "--summary-json" in sys.argv:
+        print(json.dumps(summary, indent=2))
+
+    sys.stdout.write("[GUARDIAN] " + ("PASS\n" if ok_all else "FAIL\n"))
+    sys.exit(0 if ok_all else 2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace the README with simulation-first messaging, Guardian badge, and status dashboard
- add Guardian CLI stub plus validation workflow, MkDocs config, and documentation skeleton
- introduce CONTRIBUTING guide along with issue/PR templates for Guardian-gated collaboration

## Testing
- ❌ `python scripts/guardian-cli.py --summary-json` *(fails by design until Guardian checks pass)*

------
https://chatgpt.com/codex/tasks/task_e_68ca583969a08333af67397a031cf1a3