### PR TITLE
Add trapped-ion background heating wiki pages and references

### DIFF
--- a/docs/wiki/Backgrounds---Background-Gas-Collisions-(Thermal-Flybys).md
+++ b/docs/wiki/Backgrounds---Background-Gas-Collisions-(Thermal-Flybys).md
@@ -1,0 +1,25 @@
+SPDX-License-Identifier: GPL-3.0-or-later
+
+# Background-Gas Collisions (“Thermal Flybys”)
+
+**What it is.** Collisions with residual-gas molecules cause **impulsive momentum kicks** and non-Gaussian energy tails.
+
+## Rates & signatures
+- **Langevin rate** (ion–induced dipole capture) sets a pressure-proportional collision rate \(k_L\) nearly independent of energy in the thermal regime.
+- **Statistical fingerprints:** Power-law energy/velocity tails and burstiness; mass-ratio dependent exponents.
+
+## Diagnostics we will run
+- **Pressure scans** (controlled leak or RGA-guided) to test linearity of event/heating rate vs pressure.
+- **Temporal clustering tests** (runs/over-dispersion; Ljung–Box; Allan variance).
+- **Mass dependence** when a dominant background species can be changed (e.g., He vs N\(_2\)).
+
+## Mitigations / controls
+- Improve base pressure; reduce outgassing; bake; cryo-pumping surfaces.
+- Shield from pressure spikes (valve operations, gas loads).
+
+## Primary references
+- DeVoe, **Phys. Rev. Lett. 102, 063001 (2009)** (power-law tails). DOI: 10.1103/PhysRevLett.102.063001  
+- Grier et al., **Phys. Rev. Lett. 102, 223201 (2009)** (Langevin regime in hybrid setups). DOI: 10.1103/PhysRevLett.102.223201  
+- Tomza et al., **Rev. Mod. Phys. 91, 035001 (2019)** (hybrid ion–atom review incl. Langevin). DOI: 10.1103/RevModPhys.91.035001  
+- Wineland et al., NIST notes (background gas heating discussion).  
+- Major, Gheorghe, Werth, *Charged Particle Traps* (Springer, 2005).

--- a/docs/wiki/Backgrounds---Electric-Field-Noise-(Anomalous-Heating).md
+++ b/docs/wiki/Backgrounds---Electric-Field-Noise-(Anomalous-Heating).md
@@ -1,0 +1,35 @@
+SPDX-License-Identifier: GPL-3.0-or-later
+
+# Electric-Field Noise (“Anomalous Heating”)
+
+**What it is.** Electric-field fluctuations at the ion position that drive motional excitation beyond Johnson noise expectations; commonly associated with surface effects on electrodes.
+
+## Key scalings & equations
+- Heating rate for mode of frequency \( \omega \):
+  \[
+  \dot{\bar n} = \frac{q^2}{4 m \hbar \omega} S_E(\omega)
+  \]
+  where \(S_E(\omega)\) is the one-sided electric-field noise spectral density.  
+- Typical **frequency** scaling: \(S_E(\omega) \propto \omega^{-\beta}\) with \(\beta \sim 1\) (varies by trap and treatment).
+- Typical **distance** scaling: \(S_E \propto d^{-\alpha}\), with reports near \(\alpha \approx 3\!-\!4\) in surface traps.
+- **Temperature** dependence: rapid increase with temperature; cryo operation strongly suppresses noise in many systems.
+
+## Diagnostics we will run
+- **Frequency sweep** of \(\dot{\bar n}(\omega)\) to fit \(\beta\).
+- **Distance sweep** in multizone trap (if available) to fit \(\alpha\).
+- **Temperature dependence** (if cryo) to extract \(T^\gamma\).
+- **Surface treatment tests** (Ar\(^+\) cleaning, laser cleaning) with before/after baselines.
+
+## Mitigations / controls
+- Argon-ion in-situ cleaning; pulsed-laser cleaning (355 nm) where compatible.
+- Cryogenic operation.
+- Strict surface handling / UHV cleanliness.
+
+## Primary references
+- Brownnutt, Kumph, Rabl, Blatt, **Rev. Mod. Phys. 87, 1419 (2015)**. DOI: 10.1103/RevModPhys.87.1419  
+- Turchette et al., **Phys. Rev. A 61, 063418 (2000)**. DOI: 10.1103/PhysRevA.61.063418  
+- Labaziewicz et al., **Phys. Rev. Lett. 101, 180602 (2008)**. DOI: 10.1103/PhysRevLett.101.180602  
+- Hite et al., **Phys. Rev. Lett. 109, 103001 (2012)**. DOI: 10.1103/PhysRevLett.109.103001  
+- Allcock et al., **New J. Phys. 13, 123023 (2011)**. DOI: 10.1088/1367-2630/13/12/123023  
+- Daniilidis et al., **Phys. Rev. B 89, 245435 (2014)**. DOI: 10.1103/PhysRevB.89.245435  
+- Sedlacek et al., **Phys. Rev. A 97, 020302 (2018)**. DOI: 10.1103/PhysRevA.97.020302

--- a/docs/wiki/Backgrounds---Excess-Micromotion-and-RF-Coupling.md
+++ b/docs/wiki/Backgrounds---Excess-Micromotion-and-RF-Coupling.md
@@ -1,0 +1,22 @@
+SPDX-License-Identifier: GPL-3.0-or-later
+
+# Excess Micromotion & RF Coupling
+
+**What it is.** Displacement from the RF null or phase imbalances create micromotion at \(\Omega_{\rm RF}\) that couples to noise and laser interactions.
+
+## Key relations
+- Displacement \(x_{\rm dc}\) ⇒ micromotion amplitude \(x_\mu \propto q\, x_{\rm dc}\).  
+- RF amplitude modulation \( \Delta V_0 / V_0 \) induces frequency modulation \( \Delta \omega / \omega \approx \Delta V_0 / V_0 \) and can parametrically heat motion near \(2\omega\).
+
+## Diagnostics we will run
+- **Berkeland cross-correlation** and **sideband spectroscopy** of micromotion.
+- **Drive-amplitude scans** to identify parametric sensitivity.
+- **3D compensation** (dc electrodes) with iterative nulling while monitoring sidebands.
+
+## Mitigations / controls
+- Routine 3-axis micromotion compensation; phase balancing of RF feeds; symmetric cabling.
+- Stabilize RF amplitude; monitor and log \(\Omega_{\rm RF}\) and amplitude over time.
+
+## Primary references
+- Berkeland et al., **J. Appl. Phys. 83, 5025 (1998)**. DOI: 10.1063/1.367318  
+- Leibfried et al., **RMP 75, 281 (2003)**. DOI: 10.1103/RevModPhys.75.281

--- a/docs/wiki/Backgrounds---Laser-and-Optics.md
+++ b/docs/wiki/Backgrounds---Laser-and-Optics.md
@@ -1,0 +1,21 @@
+SPDX-License-Identifier: GPL-3.0-or-later
+
+# Laser & Optics Channels
+
+**What it is.** Laser intensity/pointing/frequency noise can couple through cooling and detection beams to produce excess motion or mask true fingerprints.
+
+## How it shows up
+- **Parametric-like drive** when beam interference or intensity noise modulates effective restoring forces near \(2\omega\).
+- **Radiation-pressure fluctuations** add apparent diffusion and can bias Analog (A) scaling tests.
+
+## Diagnostics
+- Record **RIN** (relative intensity noise) spectra; compare with \(2\omega\) bands of trap modes.
+- **Beam pointing** stability on trap; AOM/TA current noise checks.
+- **Duty-cycle tests**: comparisons with beams shuttered versus on; off-resonant “dark” periods.
+
+## Mitigations
+- Intensity stabilization; low-RIN sources; fiber isolation; mechanical stability.
+
+## Primary references
+- Leibfried et al., **Rev. Mod. Phys. 75, 281 (2003)** (laser noise & ion motion basics). DOI: 10.1103/RevModPhys.75.281  
+- Brownnutt et al., **RMP 87, 1419 (2015)** (survey context).

--- a/docs/wiki/Backgrounds---Technical-Noise-(RF-and-DAC).md
+++ b/docs/wiki/Backgrounds---Technical-Noise-(RF-and-DAC).md
@@ -1,0 +1,26 @@
+SPDX-License-Identifier: GPL-3.0-or-later
+
+# Technical Noise (RF, DAC, Servo, Johnson)
+
+**What it is.** Classical noise from electronics and control systems: RF drive amplitude/phase noise, DAC update noise, ground loops, digitizer/servo artifacts, and Johnson noise.
+
+## How it heats
+- **Direct drive:** Electric-field noise at \(\omega\) couples linearly via \(\dot{\bar n} \propto S_E(\omega)\).
+- **Parametric heating:** Modulation of trap frequency at \(2\omega\) (e.g., RF amplitude noise) drives heating even if \(S_E(\omega)\) is small.
+- **Aliasing / updates:** DAC update steps and digital toggles inject narrowband components near secular/resonant frequencies.
+
+## Practical diagnostics
+- Measure **RF amplitude/phase noise**; check for spurs near \(\Omega_{\rm RF} \pm \omega\) and \(2\omega\).
+- **Notch/low-noise filters**, differential routing, star grounds; compare with trap electrodes grounded (ion removed) to bound electronics noise.
+- **Blind toggles** of control lines in acquisition to expose analysis-coupled artifacts.
+
+## Mitigations / controls
+- Quiet RF chain & shielding; amplitude-noise minimization; phase-matched lines.
+- Smoothed DAC updates (slew-rate limiters), synchronous updates far from resonances.
+- Temperature-stable references; isolation transformers; battery powering where feasible.
+
+## Primary references
+- Leibfried, Blatt, Monroe, Wineland, **Rev. Mod. Phys. 75, 281 (2003)**. DOI: 10.1103/RevModPhys.75.281  
+- Brownnutt et al., **RMP 87, 1419 (2015)**. DOI: 10.1103/RevModPhys.87.1419  
+- Wineland et al., *Experimental Issues in Coherent Quantum-State Manipulation of Trapped Ions* (NIST TN), 1998.  
+- Berkeland et al., **J. Appl. Phys. 83, 5025 (1998)** (micromotion & RF modulation). DOI: 10.1063/1.367318

--- a/docs/wiki/Physics.md
+++ b/docs/wiki/Physics.md
@@ -15,4 +15,11 @@ Motional heating in RF Paul traps can arise from:
 ### Confounders & controls
 - Micromotion (RF), laser scatter, servo or digitizer artifacts, pressure/temperature drift, analysis pipeline bias. Mitigate via pre-registration, blinding of toggles, hardware heterogeneity, and end-to-end synthetic injections.
 
+## Background mechanisms (detailed pages)
+- [Electric-Field Noise (“Anomalous Heating”)](Backgrounds---Electric-Field-Noise-(Anomalous-Heating))
+- [Technical Noise (RF and DAC)](Backgrounds---Technical-Noise-(RF-and-DAC))
+- [Excess Micromotion & RF Coupling](Backgrounds---Excess-Micromotion-and-RF-Coupling)
+- [Background-Gas Collisions (“Thermal Flybys”)](Backgrounds---Background-Gas-Collisions-(Thermal-Flybys))
+- [Laser & Optics Channels](Backgrounds---Laser-and-Optics)
+
 For deeper background, see [References](References.md).

--- a/docs/wiki/References.md
+++ b/docs/wiki/References.md
@@ -2,18 +2,26 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # References (selected primary sources)
 
-**Ion-trap noise & heating (surveys)**
-- Brownnutt, M., et al. “Ion-trap measurements of electric-field noise near surfaces.” *Rev. Mod. Phys.* **87**, 1419 (2015). DOI: 10.1103/RevModPhys.87.1419
+## Ion-trap noise & heating (surveys)
+- Brownnutt, Kumph, Rabl, Blatt, **Ion-trap measurements of electric-field noise near surfaces**, Rev. Mod. Phys. 87, 1419 (2015). DOI: 10.1103/RevModPhys.87.1419
 
-**Trapped-ion fundamentals**
-- Leibfried, D., Blatt, R., Monroe, C., Wineland, D. “Quantum dynamics of single trapped ions.” *Rev. Mod. Phys.* **75**, 281 (2003). DOI: 10.1103/RevModPhys.75.281
-- James, D. F. V. “Quantum dynamics of cold trapped ions.” *Appl. Phys. B* **66**, 181–190 (1998). DOI: 10.1007/s003400050373
-- Major, F. G., Gheorghe, V. N., Werth, G. *Charged Particle Traps: Physics and Techniques of Charged Particle Field Confinement.* Springer (2005). DOI: 10.1007/b138787
+## Trapped-ion fundamentals
+- Leibfried, Blatt, Monroe, Wineland, **Quantum dynamics of single trapped ions**, Rev. Mod. Phys. 75, 281 (2003). DOI: 10.1103/RevModPhys.75.281  
+- James, **Quantum dynamics of cold trapped ions**, Appl. Phys. B 66, 181–190 (1998). DOI: 10.1007/s003400050373  
+- Major, Gheorghe, Werth, *Charged Particle Traps* (Springer, 2005). DOI: 10.1007/b138787
 
-**Background-gas collisions / impulsive heating**
-- DeVoe, R. G. “Power-Law Distributions for a Trapped Ion Interacting with a Classical Buffer Gas.” *Phys. Rev. Lett.* **102**, 063001 (2009). DOI: 10.1103/PhysRevLett.102.063001
+## Background-gas collisions / impulsive heating
+- DeVoe, **Power-Law Distributions for a Trapped Ion Interacting with a Classical Buffer Gas**, Phys. Rev. Lett. 102, 063001 (2009). DOI: 10.1103/PhysRevLett.102.063001  
+- Grier, Cetina, Oručević, Vuletić, **Observation of Cold Collisions between Trapped Ions and Trapped Atoms**, Phys. Rev. Lett. 102, 223201 (2009). DOI: 10.1103/PhysRevLett.102.223201  
+- Tomza et al., **Cold hybrid ion–atom systems**, Rev. Mod. Phys. 91, 035001 (2019). DOI: 10.1103/RevModPhys.91.035001
 
-**Surface noise mitigation examples**
-- Hite, D. A., et al. “100-fold reduction of electric-field noise in an ion trap cleaned with in-situ Argon-ion beam.” *Phys. Rev. Lett.* **109**, 103001 (2012). DOI: 10.1103/PhysRevLett.109.103001
+## Anomalous heating: scalings & surface mitigation
+- Turchette et al., **Heating of trapped ions from the quantum ground state**, Phys. Rev. A 61, 063418 (2000). DOI: 10.1103/PhysRevA.61.063418  
+- Labaziewicz et al., **Temperature dependence of electric field noise**, Phys. Rev. Lett. 101, 180602 (2008). DOI: 10.1103/PhysRevLett.101.180602  
+- Hite et al., **100-fold reduction of electric-field noise with in-situ Ar\(^+\) cleaning**, Phys. Rev. Lett. 109, 103001 (2012). DOI: 10.1103/PhysRevLett.109.103001  
+- Allcock et al., **Reduction of heating rate by pulsed-laser cleaning**, New J. Phys. 13, 123023 (2011). DOI: 10.1088/1367-2630/13/12/123023  
+- Daniilidis et al., **Surface noise analysis using a single-ion sensor**, Phys. Rev. B 89, 245435 (2014). DOI: 10.1103/PhysRevB.89.245435  
+- Sedlacek et al., **Distance scaling of electric-field noise**, Phys. Rev. A 97, 020302 (2018). DOI: 10.1103/PhysRevA.97.020302
 
-*(Note: This list is intentionally compact; expand with lab-specific literature as the wiki grows.)*
+## Micromotion & RF coupling
+- Berkeland et al., **Minimization of ion micromotion in a Paul trap**, J. Appl. Phys. 83, 5025 (1998). DOI: 10.1063/1.367318


### PR DESCRIPTION
## Summary
- add dedicated wiki pages for key trapped-ion background heating channels with diagnostics, mitigations, and literature references
- link the new background pages from the Physics overview for easy navigation
- expand the References page with curated primary sources and DOIs spanning noise, collisions, and micromotion

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cb2bd2a924833385eb303ae6e53864