### PR TITLE
Ensure background sim guardian report serializes cleanly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,20 @@ $(PY) -m flyby.triad --data-root data/toy --out out
 
 clean:
 rm -rf out .pytest_cache .ruff_cache build dist *.egg-info
+
+.PHONY: sim-default sim-strong-patch sim-mains60
+
+sim-default:
+	python scripts/run_background_sim.py --T 300 --rf_rms 0.5 --mains 50 \
+	 --em_coupling 1e-3 --patch 5 --corr 50 --cps 200 --tint 1.0 \
+	 --n_samples 10000 --dt 1e-4 --seed 1
+
+sim-strong-patch:
+	python scripts/run_background_sim.py --T 300 --rf_rms 0.5 --mains 50 \
+	 --em_coupling 1e-3 --patch 20 --corr 200 --cps 200 --tint 1.0 \
+	 --n_samples 10000 --dt 1e-4 --seed 2
+
+sim-mains60:
+	python scripts/run_background_sim.py --T 300 --rf_rms 1.5 --mains 60 \
+	 --em_coupling 1e-3 --patch 5 --corr 50 --cps 200 --tint 1.0 \
+	 --n_samples 10000 --dt 1e-4 --seed 3

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ Launch the Background Model Explorer
 jupyter lab notebooks/Background_Model_Explorer.ipynb
 ```
 
+### Interactive / Notebooks
+
+#### Run a background simulation from CLI
+
+```bash
+python scripts/run_background_sim.py \
+  --T 300 --rf_rms 1.0 --mains 60 --em_coupling 0.002 \
+  --patch 20 --corr 200 --cps 500 --tint 2.0 \
+  --n_samples 20000 --dt 1e-4 --seed 42
+```
+
+Outputs appear in artifacts/simulations/:
+- <stamp>_time_series.png, <stamp>_psd.png, <stamp>_allan.png
+- <stamp>_guardian_report.json, <stamp>_config.json
+
 ### Physicists
 ```bash
 git clone https://github.com/uwarring82/-flyby-fingerprints-sandbox

--- a/scripts/run_background_sim.py
+++ b/scripts/run_background_sim.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""
+Run background-only simulation with user-selected parameters and save plots + a Guardian report.
+
+Outputs (written to artifacts/simulations/<timestamp>_*.{png,json}):
+  - <stamp>_time_series.png
+  - <stamp>_psd.png
+  - <stamp>_allan.png
+  - <stamp>_guardian_report.json
+  - <stamp>_config.json
+"""
+
+import argparse
+import json
+import sys
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Dict
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+try:
+    from simulation.background_effects_simulator import (
+        BackgroundConfig,
+        simulate_background_timeseries,
+    )
+    from simulation.guardian_validators.guardian_background_validator import (
+        guardian_check_backgrounds,
+    )
+except ModuleNotFoundError:  # pragma: no cover - fallback when package isn't installed
+    ROOT = Path(__file__).resolve().parents[1]
+    SRC = ROOT / "src"
+    if str(SRC) not in sys.path:
+        sys.path.insert(0, str(SRC))
+    from simulation.background_effects_simulator import (
+        BackgroundConfig,
+        simulate_background_timeseries,
+    )
+    from simulation.guardian_validators.guardian_background_validator import (
+        guardian_check_backgrounds,
+    )
+
+
+# ---------- plotting helpers ----------
+
+def _plot_time_series(
+    data: Dict[str, Any],
+    show_pos: bool = True,
+    show_em: bool = True,
+    show_surf: bool = True,
+    show_det: bool = True,
+    outpath: Path | None = None,
+) -> None:
+    plt.figure(figsize=(10, 4))
+    if show_pos:
+        plt.plot(data["position"], label="position")
+    if show_em:
+        plt.plot(data["em_pickup"], label="em_pickup")
+    if show_surf:
+        plt.plot(data["surface_drift"], label="surface_drift")
+    if show_det:
+        plt.plot(data["detector_counts"], label="detector_counts")
+    plt.legend()
+    plt.title("Background channels (time domain)")
+    plt.xlabel("Sample")
+    plt.ylabel("arb.")
+    plt.tight_layout()
+    if outpath is not None:
+        plt.savefig(outpath, dpi=180)
+    plt.close()
+
+
+def _plot_psd_em(data: Dict[str, Any], dt_s: float, outpath: Path | None = None) -> None:
+    from numpy.fft import rfft, rfftfreq
+
+    y = np.asarray(data["em_pickup"])
+    y = y - float(np.mean(y))
+    Y = np.abs(rfft(y)) ** 2
+    f = rfftfreq(len(y), dt_s)
+    # avoid the DC bin for log scale
+    f = f[1:]
+    Y = Y[1:]
+
+    plt.figure(figsize=(10, 4))
+    plt.loglog(f, Y)
+    plt.title("EM pickup PSD")
+    plt.xlabel("Frequency [Hz]")
+    plt.ylabel("Power")
+    plt.tight_layout()
+    if outpath is not None:
+        plt.savefig(outpath, dpi=180)
+    plt.close()
+
+
+def _allan_like(x: np.ndarray, dt_s: float, taus: np.ndarray) -> np.ndarray:
+    out = []
+    for tau in taus:
+        m = max(1, int(tau / dt_s))
+        blocks = len(x) // m
+        if blocks < 2:
+            out.append(np.nan)
+            continue
+        means = np.mean(x[: blocks * m].reshape(blocks, m), axis=1)
+        out.append(0.5 * np.mean(np.diff(means) ** 2))
+    return np.array(out)
+
+
+def _plot_allan_like_surface(
+    data: Dict[str, Any], dt_s: float, outpath: Path | None = None
+) -> None:
+    y = np.asarray(data["surface_drift"])
+    if len(y) < 2:
+        taus = np.array([dt_s])
+        ad = np.array([np.nan])
+    else:
+        taus = np.logspace(np.log10(10 * dt_s), np.log10(len(y) * dt_s / 5.0), 30)
+        ad = _allan_like(y, dt_s, taus)
+
+    plt.figure(figsize=(10, 4))
+    plt.loglog(taus, ad)
+    plt.title("Surface drift — Allan-like variance")
+    plt.xlabel("Tau [s]")
+    plt.ylabel("Allan-like var")
+    plt.tight_layout()
+    if outpath is not None:
+        plt.savefig(outpath, dpi=180)
+    plt.close()
+
+
+# ---------- IO helpers ----------
+
+def _json_compatible(obj: Any) -> Any:
+    """Recursively convert numpy types into JSON-serialisable Python types."""
+    if isinstance(obj, Mapping):
+        return {key: _json_compatible(value) for key, value in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_json_compatible(item) for item in obj]
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, np.generic):
+        return obj.item()
+    return obj
+
+
+def _save_json(obj: Dict[str, Any], outpath: Path) -> None:
+    outpath.parent.mkdir(parents=True, exist_ok=True)
+    with open(outpath, "w", encoding="utf-8") as f:
+        json.dump(_json_compatible(obj), f, indent=2)
+
+
+# ---------- main ----------
+
+def run_and_save(
+    *,
+    T: float,
+    rf_rms: float,
+    mains: float,
+    em_coupling: float,
+    patch: float,
+    corr: float,
+    cps: float,
+    tint_ms: float,
+    n_samples: int,
+    dt_s: float,
+    seed: int,
+    outdir: str = "artifacts/simulations",
+    show_pos: bool = True,
+    show_em: bool = True,
+    show_surf: bool = True,
+    show_det: bool = True,
+):
+    stamp = time.strftime("%Y%m%dT%H%M%S")
+    outdir_p = Path(outdir)
+    outdir_p.mkdir(parents=True, exist_ok=True)
+
+    cfg = BackgroundConfig(
+        T_kelvin=T,
+        rf_pickup_rms=rf_rms,
+        mains_hz=mains,
+        em_coupling_coeff=em_coupling,
+        patch_potential_rms_mV=patch,
+        patch_corr_length_um=corr,
+        photon_rate_bg_cps=cps,
+        readout_integration_ms=tint_ms,
+    )
+
+    data = simulate_background_timeseries(
+        n_samples=n_samples, dt_s=dt_s, cfg=cfg, seed=seed
+    )
+    report = guardian_check_backgrounds(data)
+
+    # save config + report
+    _save_json(
+        {
+            "timestamp": stamp,
+            "params": {
+                "T_kelvin": T,
+                "rf_pickup_rms_mV": rf_rms,
+                "mains_hz": mains,
+                "em_coupling_coeff": em_coupling,
+                "patch_potential_rms_mV": patch,
+                "patch_corr_length_um": corr,
+                "photon_rate_bg_cps": cps,
+                "readout_integration_ms": tint_ms,
+                "n_samples": n_samples,
+                "dt_s": dt_s,
+                "seed": seed,
+            },
+            "metadata": data.get("metadata", {}),
+        },
+        outdir_p / f"{stamp}_config.json",
+    )
+    _save_json(report, outdir_p / f"{stamp}_guardian_report.json")
+
+    # plots
+    _plot_time_series(
+        data,
+        show_pos,
+        show_em,
+        show_surf,
+        show_det,
+        outdir_p / f"{stamp}_time_series.png",
+    )
+    _plot_psd_em(data, dt_s, outdir_p / f"{stamp}_psd.png")
+    _plot_allan_like_surface(data, dt_s, outdir_p / f"{stamp}_allan.png")
+
+    return report, {
+        "config": str(outdir_p / f"{stamp}_config.json"),
+        "report": str(outdir_p / f"{stamp}_guardian_report.json"),
+        "time_series_png": str(outdir_p / f"{stamp}_time_series.png"),
+        "psd_png": str(outdir_p / f"{stamp}_psd.png"),
+        "allan_png": str(outdir_p / f"{stamp}_allan.png"),
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Run background-only simulation and save plots + Guardian report."
+    )
+    p.add_argument("--T", type=float, default=300.0, help="Temperature [K]")
+    p.add_argument("--rf_rms", type=float, default=0.5, help="RF pickup RMS [mV]")
+    p.add_argument("--mains", type=float, default=50.0, help="Mains frequency [Hz]")
+    p.add_argument(
+        "--em_coupling", type=float, default=1e-3, help="EM coupling coefficient"
+    )
+    p.add_argument("--patch", type=float, default=5.0, help="Patch potential RMS [mV]")
+    p.add_argument(
+        "--corr", type=float, default=50.0, help="Patch correlation length [um]"
+    )
+    p.add_argument("--cps", type=float, default=200.0, help="Background photon rate [counts/s]")
+    p.add_argument(
+        "--tint",
+        dest="tint_ms",
+        type=float,
+        default=1.0,
+        help="Readout integration time [ms]",
+    )
+    p.add_argument("--n_samples", type=int, default=10000, help="Number of samples")
+    p.add_argument("--dt", dest="dt_s", type=float, default=1e-4, help="Sample period [s]")
+    p.add_argument("--seed", type=int, default=42, help="PRNG seed")
+    p.add_argument(
+        "--outdir",
+        type=str,
+        default="artifacts/simulations",
+        help="Output directory",
+    )
+    # visibility toggles
+    p.add_argument("--hide_pos", action="store_true", help="Hide position trace")
+    p.add_argument("--hide_em", action="store_true", help="Hide EM pickup trace")
+    p.add_argument("--hide_surf", action="store_true", help="Hide surface drift trace")
+    p.add_argument(
+        "--hide_det", action="store_true", help="Hide detector counts trace"
+    )
+    return p
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    report, files = run_and_save(
+        T=args.T,
+        rf_rms=args.rf_rms,
+        mains=args.mains,
+        em_coupling=args.em_coupling,
+        patch=args.patch,
+        corr=args.corr,
+        cps=args.cps,
+        tint_ms=args.tint_ms,
+        n_samples=args.n_samples,
+        dt_s=args.dt_s,
+        seed=args.seed,
+        outdir=args.outdir,
+        show_pos=not args.hide_pos,
+        show_em=not args.hide_em,
+        show_surf=not args.hide_surf,
+        show_det=not args.hide_det,
+    )
+    print("Guardian report:", json.dumps(report, indent=2))
+    print("Files:", json.dumps(files, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/guardian/test_run_background_sim.py
+++ b/tests/guardian/test_run_background_sim.py
@@ -1,0 +1,44 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    import matplotlib  # noqa: F401  (imported for availability check)
+except ModuleNotFoundError:
+    _HAS_MPL = False
+else:
+    _HAS_MPL = True
+
+def test_run_and_save_smoke(tmp_path: Path):
+    if not _HAS_MPL:
+        pytest.skip(
+            "Matplotlib is required for the background simulation smoke test; run `pip install -r requirements.txt`."
+        )
+
+    from scripts.run_background_sim import run_and_save
+
+    report, files = run_and_save(
+        T=300,
+        rf_rms=0.5,
+        mains=50,
+        em_coupling=1e-3,
+        patch=5,
+        corr=50,
+        cps=200,
+        tint_ms=1.0,
+        n_samples=2000,
+        dt_s=2e-4,
+        seed=7,
+        outdir=str(tmp_path),
+    )
+    assert report.get("inventory_ok", False)
+    assert Path(files["time_series_png"]).exists()
+    assert Path(files["report"]).exists()
+    with open(files["report"], encoding="utf-8") as f:
+        json.load(f)


### PR DESCRIPTION
## Summary
- add a helper that coerces numpy scalars and arrays into JSON-serialisable Python objects
- use the helper when writing the background simulation config and Guardian report files so numpy.bool_ values no longer break JSON dumping

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68d6a85cfc588333b7d2ceeb80f0c950