### PR TITLE
Expand theory track overview and pillar scaffolding

### DIFF
--- a/theory/README.md
+++ b/theory/README.md
@@ -1,8 +1,61 @@
 # Theory Track
 
-The theory track establishes the foundational physics for fly-by fingerprint detection, defining observables, approximations, and the interfaces other tracks consume.
+The **Theory Track** defines the physics baseline for the Fly-by Fingerprints project.  
+It provides modular descriptions of ion dynamics, collisions, statistical mechanics, and detection theory.  
+All downstream tracks (Numerics, Experiments) depend on these definitions.  
 
-## Current Focus
-- Finalize baseline models for single-ion and chain dynamics.
-- Draft acceptance criteria for collision observables and mitigation knobs.
-- Maintain the shared glossary and cross-track reference points.
+> **Priority:** Theory comes first. Numerics and Experiments only start once minimal viable theory pillars are in place.  
+> **Outputs:** Pillar docs (`P*.md`), validation scripts (`validation/`), glossary (`_glossary.md`), and references (`_references.bib`).  
+
+---
+
+## Structure
+
+The theory is organized into **three tiers** and nine **pillars**:
+
+### Tier 1 – Foundational Primitives
+- [P1 — Single-Ion Dynamics](tier1_foundations/P1_single_ion_dynamics.md)  
+  *Trap Hamiltonian, secular motion, micromotion, harmonic oscillator, Lamb–Dicke regime. Provides canonical scales (ω_sec, q, a, x₀).*  
+
+- [P2 — Collision Fundamentals](tier1_foundations/P2_collision_fundamentals.md)  
+  *Ion–neutral potentials, Langevin capture, quantum scattering. Defines cross-sections and single-event transfer rates.*  
+
+### Tier 2 – System-Level & Statistical Dynamics
+- [P3 — Collective Modes in Ion Chains](tier2_system_dynamics/P3_collective_modes.md)  
+  *Normal modes of chains/crystals, axial and radial spectra, zig-zag transitions. Provides basis for mode-resolved heating.*  
+
+- [P4 — Statistical Mechanics of Collisions](tier2_system_dynamics/P4_statistical_mechanics.md)  
+  *From single collisions to ensemble heating/cooling. Rate equations and diffusion models yielding T(t) and heating rates.*  
+
+- [P5 — Structural & Plasma Regimes](tier2_system_dynamics/P5_structural_plasma.md)  
+  *Non-neutral plasma language: Debye length, Γ, liquid–solid transitions. Connects density/temperature to order parameters and phase-change signatures.*  
+
+### Tier 3 – Observational & Implementation Framework
+- [P6 — Open Quantum System Dynamics](tier3_framework/P6_open_quantum_systems.md)  
+  *Master equations, Lindblad terms, quantum trajectories. Outputs coherence times and decoherence channels from collisions.*  
+
+- [P7 — Detection & Measurement Theory](tier3_framework/P7_detection_theory.md)  
+  *Optical Bloch equations, fluorescence thermometry, sidebands, quantum jumps. Connects collisions and phase transitions to observables.*  
+
+- [P8 — Experimental Systematics & Backgrounds](tier3_framework/P8_systematics_backgrounds.md)  
+  *Catalog of technical noise (E-field, B-field, laser, detectors). Provides budgets and calibration protocols.*  
+
+- [P9 — Numerical Methods & Computational Validation](tier3_framework/P9_numerical_methods.md)  
+  *Simulation algorithms (MD, symplectic, MC collisions), convergence tests, benchmarks. Ensures reliability of numerics.*  
+
+---
+
+## Supporting Material
+
+- [`_glossary.md`](./_glossary.md): central definitions of symbols and parameters.  
+- [`_references.bib`](./_references.bib): canonical references and citations.  
+- [`validation/`](./validation/): scripts for quick, canonical checks of pillar results.  
+
+---
+
+## Contribution Guide
+
+- Draft → Minimal viable version → Guardian review → Approved.  
+- Always update the glossary when introducing symbols.  
+- Cite peer-reviewed sources via `_references.bib`.  
+- Add a validation script when introducing new derivations.  

--- a/theory/_glossary.md
+++ b/theory/_glossary.md
@@ -1,7 +1,24 @@
 # Fly-by Fingerprints Glossary
 
-Use this glossary to register symbols, operators, and recurring terminology shared across tracks. Each entry should include a concise definition and note the owning pillar or document.
+Centralized definitions of symbols, operators, and recurring terminology shared across Theory, Numerics, and Experiments. Each entry lists the owning pillar in parentheses for traceability.
 
-## Seed Entries
-- **\(\omega_z\)** — Axial trap frequency; baseline parameter for single-ion models (P1).
-- **Fly-by event** — Brief ion-neutral encounter that perturbs motional state without capture; core detection target.
+- **\(\Omega\)** — RF drive angular frequency of the Paul trap; sets the fast timescale for micromotion (P1).  
+- **\(q\)** — Mathieu stability parameter proportional to RF voltage and inverse drive frequency; determines micromotion amplitude (P1).  
+- **\(a\)** — Mathieu stability parameter capturing static confinement; together with \(q\) defines the single-ion stability map (P1).  
+- **\(\omega_{\text{sec}}\)** — Secular angular frequency describing the slow harmonic motion of a trapped ion (P1).  
+- **\(\beta\)** — Dimensionless micromotion amplitude linking secular motion to RF drive (P1).  
+- **\(x_0\)** — Ground-state spatial extent of the harmonic oscillator \(\sqrt{\hbar/(2 m \omega_{\text{sec}})}\); sets Lamb–Dicke criteria (P1).  
+- **\(\eta\)** — Lamb–Dicke parameter \(k x_0\) that quantifies coupling between motion and light (P1, P7).  
+- **\(k_L\)** — Langevin collision rate coefficient derived from ion–neutral polarization potentials (P2).  
+- **\(\sigma(E)\)** — Energy-dependent scattering cross section for ion–neutral collisions (P2).  
+- **\(D\)** — Energy diffusion constant appearing in heating models and Fokker–Planck descriptions (P4).  
+- **\(T(t)\)** — Ensemble temperature trajectory resulting from collision and cooling dynamics (P4).  
+- **\(\Gamma\)** — Coulomb coupling parameter comparing interaction to thermal energy; delineates plasma regimes (P5).  
+- **\(\lambda_D\)** — Debye screening length describing electrostatic shielding in non-neutral plasmas (P5).  
+- **\(\mathcal{L}\)** — Lindblad superoperator governing open-system evolution (P6).  
+- **\(\gamma_\phi\)** — Pure dephasing rate extracted from Lindblad terms or trajectory analysis (P6).  
+- **\(R_{\text{det}}\)** — Detected photon count rate used to infer temperature and collision events (P7).  
+- **\(S_E(\omega)\)** — Electric-field noise spectral density contributing to anomalous heating (P8).  
+- **\(\epsilon_{\text{sys}}\)** — Aggregate systematic-error budget propagated to observables (P8).  
+- **\(\delta_{\text{num}}\)** — Numerical tolerance specifying acceptable solver error per timestep (P9).  
+- **\(C_{\text{conv}}\)** — Convergence metric comparing successive simulation results or analytic baselines (P9).  

--- a/theory/_references.bib
+++ b/theory/_references.bib
@@ -1,0 +1,40 @@
+@article{Leibfried2003,
+  title        = {Quantum dynamics of single trapped ions},
+  author       = {Leibfried, Dietrich and Blatt, Rainer and Monroe, Christopher and Wineland, David J.},
+  journal      = {Reviews of Modern Physics},
+  volume       = {75},
+  number       = {1},
+  pages        = {281--324},
+  year         = {2003},
+  doi          = {10.1103/RevModPhys.75.281}
+}
+
+@article{Langevin1905,
+  title        = {Une formule fondamentale de théorie cinétique},
+  author       = {Langevin, Paul},
+  journal      = {Comptes Rendus de l'Académie des Sciences},
+  volume       = {140},
+  pages        = {150--153},
+  year         = {1905}
+}
+
+@book{NielsenChuang2010,
+  title        = {Quantum Computation and Quantum Information},
+  author       = {Nielsen, Michael A. and Chuang, Isaac L.},
+  edition      = {10th Anniversary},
+  publisher    = {Cambridge University Press},
+  address      = {Cambridge},
+  year         = {2010},
+  isbn         = {978-1-107-00217-3}
+}
+
+@book{DubinO'Neil1999,
+  title        = {Trapped Nonneutral Plasmas, Liquids, and Crystals},
+  author       = {Dubin, Daniel H.~E. and O'Neil, Thomas M.},
+  publisher    = {Reviews of Modern Physics},
+  volume       = {71},
+  number       = {1},
+  pages        = {87--172},
+  year         = {1999},
+  doi          = {10.1103/RevModPhys.71.87}
+}

--- a/theory/tier1_foundations/P1_single_ion_dynamics.md
+++ b/theory/tier1_foundations/P1_single_ion_dynamics.md
@@ -1,0 +1,30 @@
+# Pillar 1: Single-Ion Dynamics
+
+**Scope**  
+This pillar establishes the baseline physics of a single ion confined in a radio-frequency (RF) Paul trap. It covers the Mathieu equation of motion, secular motion, micromotion, and the mapping to the quantum harmonic oscillator.  
+The discussion also sets the Lamb–Dicke regime, zero-point fluctuations, and canonical scaling laws that downstream tracks reuse when benchmarking trap configurations.
+
+**Inputs**  
+- Trap parameters: RF drive frequency Ω, voltage V, characteristic electrode dimension r₀  
+- Ion species: mass m, charge e, and polarizability α  
+- Reference experimental context: Mg⁺ and Ba⁺ benchmark systems  
+
+**Outputs**  
+- Secular frequencies (ω_sec), micromotion amplitude β, and stability parameters (q, a)  
+- Ground-state spread x₀ and Lamb–Dicke parameters for reference species  
+- Tabulated canonical scales for energy, length, and time used across the project  
+
+**Acceptance Criteria**  
+- [ ] Derive secular frequency ω_sec for Mg⁺ and Ba⁺ at reference trap parameters  
+- [ ] Verify dimensional consistency and stability boundaries of Mathieu q, a parameters  
+- [ ] Plot a representative stability diagram highlighting operating points  
+- [ ] Compute ground-state spread x₀ and Lamb–Dicke η for both benchmark ions  
+- [ ] Register glossary entries for q, a, ω_sec, β, x₀, and η  
+
+**Validation Script**  
+- File: `theory/validation/P1_trap_frequencies.py`  
+- Purpose: Calculate ω_sec, β, and generate the stability diagram for reference traps  
+
+**Notes & References**  
+- See [`_glossary.md`](../_glossary.md) for symbol definitions shared across pillars.  
+- Cite Wineland *et al.* and related trap design references listed in [`_references.bib`](../_references.bib).  

--- a/theory/tier1_foundations/P2_collision_fundamentals.md
+++ b/theory/tier1_foundations/P2_collision_fundamentals.md
@@ -1,0 +1,30 @@
+# Pillar 2: Collision Fundamentals
+
+**Scope**  
+This pillar characterizes binary ion–neutral encounters from classical and quantum perspectives. It develops ion–neutral potentials, Langevin capture rates, and the role of polarization forces, then extends to partial-wave scattering and energy-dependent cross sections.  
+The goal is to translate microscopic collision physics into rate coefficients and momentum-transfer kernels that higher-tier pillars reuse.
+
+**Inputs**  
+- Trap environment from [Pillar 1](P1_single_ion_dynamics.md): secular frequencies, velocity scales  
+- Neutral background properties: species, density, temperature, polarizability  
+- Atomic constants and potential parameters sourced from literature  
+
+**Outputs**  
+- Langevin capture rates, elastic/inelastic cross sections σ(E), and momentum-transfer coefficients  
+- Energy and angular distributions for single-collision events  
+- Parameterized collision kernels supplied to statistical and open-system models  
+
+**Acceptance Criteria**  
+- [ ] Derive Langevin rate constant and compare with reference data  
+- [ ] Compute σ(E) for benchmark neutral species with uncertainty estimates  
+- [ ] Document thresholds for inelastic channels relevant to Mg⁺ and Ba⁺  
+- [ ] Provide sampling routines for scattering angle distributions  
+- [ ] Update glossary entries for σ(E), k_L, and polarization potentials  
+
+**Validation Script**  
+- File: `theory/validation/P2_collision_rates.py`  
+- Purpose: Evaluate Langevin rates and generate σ(E) curves across relevant energies  
+
+**Notes & References**  
+- See [`_glossary.md`](../_glossary.md) for symbols such as σ(E) and k_L.  
+- Reference Langevin (1905) and modern collision reviews cited in [`_references.bib`](../_references.bib).  

--- a/theory/tier2_system_dynamics/P3_collective_modes.md
+++ b/theory/tier2_system_dynamics/P3_collective_modes.md
@@ -1,0 +1,30 @@
+# Pillar 3: Collective Modes in Ion Chains
+
+**Scope**  
+This pillar studies the normal-mode structure of ion chains and Coulomb crystals under realistic trap conditions. It extends single-ion dynamics to many-body configurations, analyzing axial and radial spectra, mode couplings, and structural transitions such as zig-zag instabilities.  
+Results set the mechanical eigenbasis required to describe heating, cooling, and detection channels in subsequent pillars.
+
+**Inputs**  
+- Single-ion frequencies and scaling laws from [Pillar 1](../tier1_foundations/P1_single_ion_dynamics.md)  
+- Inter-ion spacing, crystal geometry, and ion number  
+- Trap anisotropy parameters and boundary conditions  
+
+**Outputs**  
+- Mode matrices, eigenfrequencies, and participation factors for axial/radial branches  
+- Stability thresholds for structural transitions across parameter sweeps  
+- Reduced models for mode-resolved coupling to collisions and detection schemes  
+
+**Acceptance Criteria**  
+- [ ] Compute mode spectra for linear chains of 2–50 ions with convergence tests  
+- [ ] Identify zig-zag transition points as functions of trap anisotropy  
+- [ ] Provide mode participation tables consumable by numerics and detection models  
+- [ ] Quantify sensitivity of key modes to stray fields and micromotion  
+- [ ] Add glossary entries for normal-mode indices and participation factors  
+
+**Validation Script**  
+- File: `theory/validation/P3_mode_spectra.py`  
+- Purpose: Generate axial and radial mode spectra, verifying transition thresholds  
+
+**Notes & References**  
+- Consult [`_glossary.md`](../_glossary.md) for mode-labeling conventions.  
+- Cite non-neutral plasma and trapped-ion normal-mode references listed in [`_references.bib`](../_references.bib).  

--- a/theory/tier2_system_dynamics/P4_statistical_mechanics.md
+++ b/theory/tier2_system_dynamics/P4_statistical_mechanics.md
@@ -1,0 +1,30 @@
+# Pillar 4: Statistical Mechanics of Collisions
+
+**Scope**  
+This pillar bridges single-collision physics to ensemble-level heating and cooling dynamics. It formulates rate equations, Fokker–Planck descriptions, and stochastic models that capture how repeated interactions shape motional energy and temperature evolution.  
+Outputs set the canonical heating-rate benchmarks and uncertainty budgets required by experiments and numerics.
+
+**Inputs**  
+- Collision kernels and cross sections from [Pillar 2](../tier1_foundations/P2_collision_fundamentals.md)  
+- Mode structures and participation factors from [Pillar 3](P3_collective_modes.md)  
+- Environmental parameters: background gas density, trap drive noise, and cooling rates  
+
+**Outputs**  
+- Closed-form and numerical models for temperature evolution T(t) and energy diffusion  
+- Mode-resolved heating rates and cross-talk matrices  
+- Criteria for steady-state temperatures under various cooling strategies  
+
+**Acceptance Criteria**  
+- [ ] Derive rate-equation models linking Langevin rates to T(t)  
+- [ ] Validate diffusion coefficients against Monte Carlo simulations  
+- [ ] Provide uncertainty propagation for density and cross-section inputs  
+- [ ] Tabulate mode-resolved heating budgets for representative traps  
+- [ ] Add glossary entries for diffusion constants and heating metrics  
+
+**Validation Script**  
+- File: `theory/validation/P4_heating_models.py`  
+- Purpose: Compare analytic heating predictions with stochastic simulation benchmarks  
+
+**Notes & References**  
+- See [`_glossary.md`](../_glossary.md) for definitions of diffusion constants and heating rates.  
+- Reference statistical mechanics and ion-heating literature listed in [`_references.bib`](../_references.bib).  

--- a/theory/tier2_system_dynamics/P5_structural_plasma.md
+++ b/theory/tier2_system_dynamics/P5_structural_plasma.md
@@ -1,0 +1,30 @@
+# Pillar 5: Structural & Plasma Regimes
+
+**Scope**  
+This pillar maps trapped-ion ensembles onto non-neutral plasma frameworks, clarifying when the system behaves like a liquid, solid, or plasma. It introduces Debye screening, Coulomb coupling Γ, and order parameters that signal phase transitions.  
+These results provide diagnostic criteria for when collision-driven heating or external perturbations will trigger structural changes relevant to detection.
+
+**Inputs**  
+- Mode structure and spacing from [Pillar 3](P3_collective_modes.md)  
+- Temperature evolution and diffusion constants from [Pillar 4](P4_statistical_mechanics.md)  
+- Trap geometry and density distributions from experimental specifications  
+
+**Outputs**  
+- Phase diagrams linking Γ, λ_D, and density to structural regimes  
+- Order parameters and signatures for liquid–solid transitions and plasma behavior  
+- Threshold criteria for triggering crystal melting or recrystallization  
+
+**Acceptance Criteria**  
+- [ ] Compute Γ and λ_D for benchmark trap conditions and background gases  
+- [ ] Produce regime maps showing transitions among crystalline, liquid, and plasma states  
+- [ ] Quantify impact of collision-driven heating on structural transitions  
+- [ ] Provide guidelines for experimental diagnostics of regime changes  
+- [ ] Add glossary entries for Γ, λ_D, and relevant order parameters  
+
+**Validation Script**  
+- File: `theory/validation/P5_plasma_regimes.py`  
+- Purpose: Evaluate Γ and λ_D across parameter scans and overlay regime boundaries  
+
+**Notes & References**  
+- Consult [`_glossary.md`](../_glossary.md) for plasma-physics terminology.  
+- Reference non-neutral plasma texts and experimental studies listed in [`_references.bib`](../_references.bib).  

--- a/theory/tier3_framework/P6_open_quantum_systems.md
+++ b/theory/tier3_framework/P6_open_quantum_systems.md
@@ -1,0 +1,30 @@
+# Pillar 6: Open Quantum System Dynamics
+
+**Scope**  
+This pillar formulates the reduced dynamics of trapped-ion qubits and motional states subject to collision-induced decoherence. It develops master equations, Lindblad operators, and quantum-trajectory approaches that translate microscopic scattering processes into coherence-loss channels.  
+Outputs provide coherence-time predictions and error budgets necessary for interpreting detection signals and quantum information metrics.
+
+**Inputs**  
+- Collision kernels and energy transfer models from [Pillar 2](../tier1_foundations/P2_collision_fundamentals.md)  
+- Mode structures and heating rates from [Pillars 3](../tier2_system_dynamics/P3_collective_modes.md) and [4](../tier2_system_dynamics/P4_statistical_mechanics.md)  
+- Control protocols and laser parameters supplied by experimental design documents  
+
+**Outputs**  
+- Lindblad representations of collision-induced decoherence channels  
+- Quantum-trajectory tools for rare but high-impact events  
+- Coherence-time and error-rate predictions for qubit and motional observables  
+
+**Acceptance Criteria**  
+- [ ] Derive master equations capturing collision-induced dephasing and heating  
+- [ ] Benchmark Lindblad parameters against stochastic simulations  
+- [ ] Quantify coherence-time reduction versus collision rates and mode participation  
+- [ ] Provide recommendations for mitigation strategies (e.g., dynamical decoupling)  
+- [ ] Update glossary entries for Lindblad operators, decoherence rates, and trajectories  
+
+**Validation Script**  
+- File: `theory/validation/P6_open_systems.py`  
+- Purpose: Compare master-equation predictions with trajectory-based simulations  
+
+**Notes & References**  
+- Use [`_glossary.md`](../_glossary.md) for open-system notation consistency.  
+- Cite Nielsen & Chuang and relevant open quantum systems texts in [`_references.bib`](../_references.bib).  

--- a/theory/tier3_framework/P7_detection_theory.md
+++ b/theory/tier3_framework/P7_detection_theory.md
@@ -1,0 +1,30 @@
+# Pillar 7: Detection & Measurement Theory
+
+**Scope**  
+This pillar links collision-driven dynamics to observable signals by modeling fluorescence detection, sideband spectroscopy, and quantum jump statistics. It derives measurement operators, signal-to-noise ratios, and estimation frameworks for inferring collisions from photonic data.  
+The results specify how experiments and numerics should process raw observables to extract temperature, phase, and decoherence metrics.
+
+**Inputs**  
+- Open-system dynamics and decoherence channels from [Pillar 6](P6_open_quantum_systems.md)  
+- Mode participation data from [Pillars 3](../tier2_system_dynamics/P3_collective_modes.md) and [4](../tier2_system_dynamics/P4_statistical_mechanics.md)  
+- Detector characteristics, optical pumping parameters, and laser noise models  
+
+**Outputs**  
+- Optical Bloch and rate-equation models producing fluorescence and sideband spectra  
+- Mapping from observed counts to motional state estimates and collision detection thresholds  
+- Guidelines for experiment/numerics interfaces, including required calibration data  
+
+**Acceptance Criteria**  
+- [ ] Derive fluorescence versus temperature curves with uncertainty propagation  
+- [ ] Model sideband asymmetry as a function of mode occupations  
+- [ ] Quantify detection efficiency and false-positive/negative rates for collision events  
+- [ ] Provide calibration routines for detector backgrounds and laser drifts  
+- [ ] Update glossary entries for detection efficiencies, branching ratios, and count statistics  
+
+**Validation Script**  
+- File: `theory/validation/P7_detection_models.py`  
+- Purpose: Simulate fluorescence and sideband signals for benchmark scenarios and compare against analytic predictions  
+
+**Notes & References**  
+- See [`_glossary.md`](../_glossary.md) for detection-related symbols and parameters.  
+- Reference optical Bloch equation literature and measurement theory texts cited in [`_references.bib`](../_references.bib).  

--- a/theory/tier3_framework/P8_systematics_backgrounds.md
+++ b/theory/tier3_framework/P8_systematics_backgrounds.md
@@ -1,0 +1,30 @@
+# Pillar 8: Experimental Systematics & Backgrounds
+
+**Scope**  
+This pillar catalogs technical noise sources and systematic effects that perturb trapped-ion dynamics or mask collision signatures. It covers electric- and magnetic-field noise, laser intensity/frequency fluctuations, detection electronics, and vacuum-related drifts.  
+Outputs provide mitigation strategies, calibration plans, and residual uncertainty budgets that experiments must track.
+
+**Inputs**  
+- Trap operating points and mode sensitivities from [Pillars 1](../tier1_foundations/P1_single_ion_dynamics.md) and [3](../tier2_system_dynamics/P3_collective_modes.md)  
+- Heating and decoherence models from [Pillars 4](../tier2_system_dynamics/P4_statistical_mechanics.md) and [6](P6_open_quantum_systems.md)  
+- Detector and laser specifications from experimental design notes  
+
+**Outputs**  
+- Comprehensive noise budget tables with frequency- and mode-dependent couplings  
+- Calibration protocols and monitoring procedures for key systematics  
+- Residual uncertainty estimates propagated to detection metrics  
+
+**Acceptance Criteria**  
+- [ ] Enumerate dominant electric, magnetic, and laser noise channels with scaling laws  
+- [ ] Provide calibration and monitoring checklists for each subsystem  
+- [ ] Quantify impact of systematics on heating and coherence benchmarks  
+- [ ] Recommend mitigation strategies prioritized by feasibility and payoff  
+- [ ] Update glossary entries for noise spectral densities and systematic budgets  
+
+**Validation Script**  
+- File: `theory/validation/P8_systematics_budget.py`  
+- Purpose: Aggregate noise spectra, propagate to heating/coherence metrics, and flag outliers  
+
+**Notes & References**  
+- See [`_glossary.md`](../_glossary.md) for noise-budget terminology.  
+- Cite technical noise and systematic-error references listed in [`_references.bib`](../_references.bib).  

--- a/theory/tier3_framework/P9_numerical_methods.md
+++ b/theory/tier3_framework/P9_numerical_methods.md
@@ -1,0 +1,30 @@
+# Pillar 9: Numerical Methods & Computational Validation
+
+**Scope**  
+This pillar documents the computational techniques required to simulate ion dynamics, collisions, and detection signals. It specifies molecular dynamics (MD), symplectic integrators, Monte Carlo collision sampling, and hybrid quantum-classical solvers, emphasizing accuracy, stability, and reproducibility.  
+The pillar defines the validation workflow connecting theory-derived models to numerics and experimental cross-checks.
+
+**Inputs**  
+- Physical models, rates, and parameters from [Pillars 1–8](../_glossary.md) via referenced outputs  
+- Benchmark scenarios and acceptance metrics defined by upstream pillars  
+- Software engineering standards from the numerics track  
+
+**Outputs**  
+- Recommended algorithms, timestep constraints, and convergence criteria for each modeling regime  
+- Reference implementations or pseudocode for key solvers and coupling schemes  
+- Validation plans comparing simulations with analytic results and experimental data  
+
+**Acceptance Criteria**  
+- [ ] Document algorithm selection guidelines for MD, symplectic, and Monte Carlo approaches  
+- [ ] Provide convergence and stability tests tied to upstream acceptance criteria  
+- [ ] Define data formats and interfaces for exchanging results with numerics and experiments  
+- [ ] Establish reproducibility checklist including seeding, versioning, and benchmarking requirements  
+- [ ] Add glossary entries for numerical tolerances and convergence metrics  
+
+**Validation Script**  
+- File: `theory/validation/P9_numerics_validation.py`  
+- Purpose: Execute reference simulations and compare against analytic baselines from earlier pillars  
+
+**Notes & References**  
+- Leverage [`_glossary.md`](../_glossary.md) to align algorithm terminology with physics definitions.  
+- Cite computational physics and trapped-ion simulation references listed in [`_references.bib`](../_references.bib).  


### PR DESCRIPTION
## Summary
- expand the theory track README with a tiered pillar overview and supporting links
- add scope, inputs/outputs, acceptance criteria, and validation hooks for all nine theory pillars
- seed the shared glossary and references with core symbols and canonical literature citations

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68da661391ac8333bb842af0b14819aa