### PR TITLE
Link repository to wiki and add navigation cues

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,6 @@
+repository:
+  homepage: https://github.com/uwarring82/-flyby-fingerprints-sandbox/wiki
+  topics:
+    - ion-trap
+    - collision-physics
+    - numerical-simulation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Fly-by Fingerprints Sandbox
 
+[Wiki Home](https://github.com/uwarring82/-flyby-fingerprints-sandbox/wiki) · [Theory Track](/theory) · [Numerics Track](/numerics) · [Experiments Track](/experiments) · [Status](./STATUS.md)
+
 Ion–neutral collision signatures in trapped-ion systems: a sandbox to develop the theory, numerics, and experimental playbooks needed to detect and interpret fly-by events.
 
 > **Working mode:** Three tracks run in parallel — **Theory (priority 1)**, **Numerics (priority 2)**, **Experiments (priority 3)** — with agile, rolling decisions.
@@ -75,6 +77,12 @@ pip install -r requirements.txt  # if present
 - Parallel tracks with rolling gates; Phase-2 (numerics) may start once Theory drafts provide safe-to-consume interfaces.
 - Minimal viable drafts first; refine iteratively.
 - Validation first: every new model or kernel ships with a tiny, runnable check.
+
+---
+
+## Documentation & Guides
+
+- **Start in the Wiki:** [Wiki Home](https://github.com/uwarring82/-flyby-fingerprints-sandbox/wiki) · [Guardian Workflows](https://github.com/uwarring82/-flyby-fingerprints-sandbox/wiki/Guardian_Workflows) · [Theory Track](https://github.com/uwarring82/-flyby-fingerprints-sandbox/wiki/Theory_Track) · [Numerics Track](https://github.com/uwarring82/-flyby-fingerprints-sandbox/wiki/Numerics_Track) · [Experiments Track](https://github.com/uwarring82/-flyby-fingerprints-sandbox/wiki/Experiments_Track)
 
 ---
 

--- a/experiments/templates/README.md
+++ b/experiments/templates/README.md
@@ -1,0 +1,3 @@
+# Experiment Templates
+
+This directory houses calibration worksheets, acquisition checklists, and run sheets aligned with the Experiments Track. Populate each template with the minimum viable fields needed for Guardian review before executing a new procedure.

--- a/wiki/Background_Effects_Catalog.md
+++ b/wiki/Background_Effects_Catalog.md
@@ -15,4 +15,4 @@
 - [ ] Update the table above with owner, file links, and status.
 
 ---
-Last synchronized with main on 2025-10-06 (commit fe72749). Owner: CODEX.
+Last synchronized with main on 2025-10-06 (commit 7fb7095). Owner: CODEX.

--- a/wiki/Contributing_Shortcuts.md
+++ b/wiki/Contributing_Shortcuts.md
@@ -18,4 +18,4 @@
 - [ ] Run Guardian CLI (`python scripts/guardian-cli.py --strict`) before requesting review when applicable.
 
 ---
-Last synchronized with main on 2025-10-06 (commit fe72749). Owner: CODEX.
+Last synchronized with main on 2025-10-06 (commit 7fb7095). Owner: CODEX.

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -15,4 +15,4 @@
 Refer to the canonical glossary for the full set and owning pillars.
 
 ---
-Last synchronized with main on 2025-10-06 (commit fe72749). Owner: CODEX.
+Last synchronized with main on 2025-10-06 (commit 7fb7095). Owner: CODEX.

--- a/wiki/Guardian_Workflows.md
+++ b/wiki/Guardian_Workflows.md
@@ -25,4 +25,4 @@ python scripts/guardian-cli.py --all --summary-json --strict
 - Additional smoke checks (e.g., Binder imports) may surface as optional jobs.
 
 ---
-Last synchronized with main on 2025-10-06 (commit fe72749). Owner: CODEX.
+Last synchronized with main on 2025-10-06 (commit 7fb7095). Owner: CODEX.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -17,12 +17,15 @@
 | 2 | [Status Dashboard](Status_Dashboard) | Human-readable summary → live STATUS.md |
 | Quick utility | [Reporting Format](../blob/main/REPORTING.md) | Guardian-compliant progress/run notes |
 
-## Quick Links
-- [Tracks landing](Project_Overview#tracks)
-- [Theory entry folder](../tree/main/theory/)
-- [Numerics entry folder](../tree/main/numerics/)
-- [Experiments entry folder](../tree/main/experiments/)
-- [Docs portal (MkDocs)](../tree/main/docs/) — `mkdocs.yml` defines the manuals site scaffold.
+> **Quick Links**
+> - [Theory folder](../tree/main/theory/)
+> - [Numerics folder](../tree/main/numerics/)
+> - [Experiments folder](../tree/main/experiments/)
+> - [STATUS.md](../blob/main/STATUS.md)
+> - [REPORTING.md](../blob/main/REPORTING.md)
+> - [Theory Track (wiki)](Tracks/Theory_Track)
+> - [Numerics Track (wiki)](Tracks/Numerics_Track)
+> - [Experiments Track (wiki)](Tracks/Experiments_Track)
 
 ---
-Last synchronized with main on 2025-10-06 (commit fe72749). Owner: CODEX.
+Last synchronized with main on 2025-10-06 (commit 7fb7095). Owner: CODEX.

--- a/wiki/Pillars_Index.md
+++ b/wiki/Pillars_Index.md
@@ -20,4 +20,4 @@
 5. Update this index with status + link.
 
 ---
-Last synchronized with main on 2025-10-06 (commit fe72749). Owner: CODEX.
+Last synchronized with main on 2025-10-06 (commit 7fb7095). Owner: CODEX.

--- a/wiki/Project_Overview.md
+++ b/wiki/Project_Overview.md
@@ -31,4 +31,4 @@ This wiki orients contributors; manuals and specs live in the repo.
 | Reporting cadence | [`REPORTING.md`](../blob/main/REPORTING.md) |
 
 ---
-Last synchronized with main on 2025-10-06 (commit fe72749). Owner: CODEX.
+Last synchronized with main on 2025-10-06 (commit 7fb7095). Owner: CODEX.

--- a/wiki/Status_Dashboard.md
+++ b/wiki/Status_Dashboard.md
@@ -18,4 +18,4 @@
 - [ ] I/O preserves ground-truth metadata
 
 ---
-Last synchronized with main on 2025-10-06 (commit fe72749). Owner: CODEX.
+Last synchronized with main on 2025-10-06 (commit 7fb7095). Owner: CODEX.

--- a/wiki/Tracks/Experiments_Track.md
+++ b/wiki/Tracks/Experiments_Track.md
@@ -1,11 +1,11 @@
 # Experiments Track
 
+> Source in repo → [experiments/](../../tree/main/experiments/) · [templates/](../../tree/main/experiments/templates/)
+
 ## Purpose & Outputs
 - [ ] Encode procedures, calibration steps, and acquisition templates aligned with Guardian requirements.
 - [ ] Characterize backgrounds before discovery claims.
 - [ ] Provide lab-ready notebooks and data hooks for validation imports.
-- Entry folder: [`experiments/`](../../tree/main/experiments/)
-
 ## Operating Stance
 - Background-first: experiments currently support characterization and validation, **not** new discovery campaigns.
 - Consume stable models from [Theory Track](Theory_Track) and numerical harnesses from [Numerics Track](Numerics_Track).
@@ -17,4 +17,4 @@
 |  |  |  |  |  |  |
 
 ---
-Last synchronized with main on 2025-10-06 (commit fe72749). Owner: CODEX.
+Last synchronized with main on 2025-10-06 (commit 7fb7095). Owner: CODEX.

--- a/wiki/Tracks/Numerics_Track.md
+++ b/wiki/Tracks/Numerics_Track.md
@@ -1,11 +1,11 @@
 # Numerics Track
 
+> Source in repo → [numerics/](../../tree/main/numerics/) · [Guardian CI workflow](../../blob/main/.github/workflows/guardian-validation.yml) · [guardian-cli.py](../../blob/main/scripts/guardian-cli.py)
+
 ## Purpose & Outputs
 - [ ] Build molecular dynamics & symplectic integrators aligned with Theory interfaces.
 - [ ] Implement Monte Carlo collision kernels and convergence harnesses.
 - [ ] Maintain CI hooks for Guardian validation.
-- Entry folder: [`numerics/`](../../tree/main/numerics/)
-
 ## Interfaces Consumed from Theory
 | Interface | Status | Source |
 | --- | --- | --- |
@@ -19,4 +19,4 @@
 - [ ] Guardian ROC suites activated once thresholds lock — see [Guardian Workflows](../Guardian_Workflows).
 
 ---
-Last synchronized with main on 2025-10-06 (commit fe72749). Owner: CODEX.
+Last synchronized with main on 2025-10-06 (commit 7fb7095). Owner: CODEX.

--- a/wiki/Tracks/Theory_Track.md
+++ b/wiki/Tracks/Theory_Track.md
@@ -1,11 +1,11 @@
 # Theory Track
 
+> Source in repo → [theory/](../../tree/main/theory/) · [_glossary.md](../../blob/main/theory/_glossary.md)
+
 ## Purpose & Outputs
 - [ ] Define Pillar specifications (P1–P9) with acceptance checklists.
 - [ ] Publish validation snippets to unblock Numerics and Experiments.
 - [ ] Steward the shared symbol glossary and interface definitions.
-- Entry folder: [`theory/`](../../tree/main/theory/)
-
 ## Active Focus — P1 Single-Ion Dynamics
 | Item | Pointer |
 | --- | --- |
@@ -24,4 +24,4 @@
 - [ ] Validation snippets comparing trap frequencies vs. analytics committed.
 
 ---
-Last synchronized with main on 2025-10-06 (commit fe72749). Owner: CODEX.
+Last synchronized with main on 2025-10-06 (commit 7fb7095). Owner: CODEX.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,1 @@
+↑ Back to repo: [Code](../) · [Issues](../issues) · [Actions](../actions) · [README](../#readme)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,12 @@
+- [Home](Home)
+- [Project Overview](Project_Overview)
+- Tracks
+  - [Theory Track](Tracks/Theory_Track)
+  - [Numerics Track](Tracks/Numerics_Track)
+  - [Experiments Track](Tracks/Experiments_Track)
+- [Pillars Index](Pillars_Index)
+- [Background Effects Catalog](Background_Effects_Catalog)
+- [Guardian Workflows](Guardian_Workflows)
+- [Status Dashboard](Status_Dashboard)
+- [Contributing Shortcuts](Contributing_Shortcuts)
+- [Glossary](Glossary)


### PR DESCRIPTION
## Summary
- add README navigation row and documentation pointers that highlight the wiki
- configure the repository homepage/topics and add an experiments templates directory for cross-linking
- create wiki sidebar/footer, quick links, and bidirectional repo anchors with refreshed synchronization footers

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e39bab089c8333bce5e75e3f8da402